### PR TITLE
aarch64: Add tbz and tbnz to branch_instructions

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -460,7 +460,7 @@ elif arch == "aarch64":
     re_imm = re.compile(r"(?<!sp, )#-?(0x[0-9a-fA-F]+|[0-9]+)\b")
     forbidden = set(string.ascii_letters + "_")
     branch_likely_instructions = set()
-    branch_instructions = {"bl", "b", "b.eq", "b.ne", "b.cs", "b.hs", "b.cc", "b.lo", "b.mi", "b.pl", "b.vs", "b.vc", "b.hi", "b.ls", "b.ge", "b.lt", "b.gt", "b.le", "cbz", "cbnz"}
+    branch_instructions = {"bl", "b", "b.eq", "b.ne", "b.cs", "b.hs", "b.cc", "b.lo", "b.mi", "b.pl", "b.vs", "b.vc", "b.hi", "b.ls", "b.ge", "b.lt", "b.gt", "b.le", "cbz", "cbnz", "tbz", "tbnz"}
     instructions_with_address_immediates = branch_instructions.union({"adrp"})
 else:
     fail("Unknown architecture.")


### PR DESCRIPTION
Accidentally left them out, whoops!

I've checked the instruction list and there should be no other
branch instructions that take an address.