### PR TITLE
Fix missing incoming branch arrows in some cases

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -589,7 +589,7 @@ def process(lines):
             target = row_parts[1].strip().split(",")[-1]
             if mnemonic in branch_likely_instructions:
                 target = hex(int(target, 16) - 4)[2:]
-            branch_targets.append(target)
+            branch_targets.append(target.strip())
         else:
             branch_targets.append(None)
         if args.stop_jrra and mnemonic == "jr" and row_parts[1].strip() == "ra":


### PR DESCRIPTION
Line numbers are always stripped, so branch targets should also be
stripped to avoid any mismatch.

It seems this affects instructions with two operands like
"cbz     x0, 52c4" -- the branch target would be " 52c4".
"b 52c4" on the other hand isn't affected.