### PR TITLE
Delay stop jr ra to after the delay slot.

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -565,6 +565,7 @@ def process(lines):
             lines.pop()
 
     output = []
+    stop_after_delay_slot = False
     for row in lines:
         if args.diff_obj and (">:" in row or not row):
             continue
@@ -634,6 +635,8 @@ def process(lines):
         source_lines = []
 
         if args.stop_jrra and mnemonic == "jr" and row_parts[1].strip() == "ra":
+            stop_after_delay_slot = True
+        elif stop_after_delay_slot:
             break
 
     # Cleanup whitespace, after relocation fixups have happened


### PR DESCRIPTION
This causes the -s option to stop on the instruction after `jr ra` to show the delay slot.