### PR TITLE
tab-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,21 @@ Create a file `diff-settings.sh` in some directory (see the one in this repo for
 ```
 
 Recommended flags are `-mwo` (automatically run `make` on source file changes, and include symbols in diff). See `--help` for more details.
+
+### Tab completion
+
+[argcomplete](https://kislyuk.github.io/argcomplete/) can be optionally installed (with `python3 -m pip install argcomplete`) to enable tab completion in a bash shell, completing options and symbol names using the linker map. It also requires a bit more setup:
+
+If invoking the script **exactly** as `./diff.py`, the following should be added to the `.bashrc` according to argcomplete's instructions:
+
+```sh
+eval "$(register-python-argcomplete ./diff.py)"
+```
+
+If that doesn't work, run `register-python-argcomplete ./diff.py` in your terminal and copy the output to `.bashrc`.
+
+If setup correctly (don't forget to restart the shell), `complete | grep ./diff.py` should output:
+
+```
+complete -o bashdefault -o default -o nospace -F _python_argcomplete ./diff.py
+```

--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ If setup correctly (don't forget to restart the shell), `complete | grep ./diff.
 ```
 complete -o bashdefault -o default -o nospace -F _python_argcomplete ./diff.py
 ```
+
+Note for developers or for general troubleshooting: run `export _ARC_DEBUG=` to enable debug output during tab-completion, it may show otherwise silenced errors. Use `unset _ARC_DEBUG` or restart the terminal to disable.

--- a/diff.py
+++ b/diff.py
@@ -1,39 +1,9 @@
 #!/usr/bin/env python3
 import sys
-import re
-import os
-import ast
-try:
-    import argcomplete
-except ModuleNotFoundError:
-    argcomplete = None
-import argparse
-import subprocess
-import difflib
-import string
-import itertools
-import threading
-import queue
-import time
-from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple, Union
-
 
 def fail(msg):
     print(msg, file=sys.stderr)
     sys.exit(1)
-
-
-MISSING_PREREQUISITES = (
-    "Missing prerequisite python module {}. "
-    "Run `python3 -m pip install --user colorama ansiwrap watchdog python-Levenshtein cxxfilt` to install prerequisites (cxxfilt only needed with --source)."
-)
-
-try:
-    from colorama import Fore, Style, Back  # type: ignore
-    import ansiwrap  # type: ignore
-    import watchdog  # type: ignore
-except ModuleNotFoundError as e:
-    fail(MISSING_PREREQUISITES.format(e.name))
 
 # Prefer to use diff_settings.py from the current working directory
 sys.path.insert(0, ".")
@@ -41,8 +11,15 @@ try:
     import diff_settings
 except ModuleNotFoundError:
     fail("Unable to find diff_settings.py in the same directory.")
+sys.path.pop(0)
 
-# ==== CONFIG ====
+# ==== COMMAND-LINE ====
+
+try:
+    import argcomplete
+except ModuleNotFoundError:
+    argcomplete = None
+import argparse
 
 parser = argparse.ArgumentParser(description="Diff MIPS assembly.")
 
@@ -201,6 +178,35 @@ if hasattr(diff_settings, "add_custom_arguments"):
 
 if argcomplete:
     argcomplete.autocomplete(parser)
+
+# ==== IMPORTS ====
+
+import re
+import os
+import ast
+import subprocess
+import difflib
+import string
+import itertools
+import threading
+import queue
+import time
+from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple, Union
+
+
+MISSING_PREREQUISITES = (
+    "Missing prerequisite python module {}. "
+    "Run `python3 -m pip install --user colorama ansiwrap watchdog python-Levenshtein cxxfilt` to install prerequisites (cxxfilt only needed with --source)."
+)
+
+try:
+    from colorama import Fore, Style, Back  # type: ignore
+    import ansiwrap  # type: ignore
+    import watchdog  # type: ignore
+except ModuleNotFoundError as e:
+    fail(MISSING_PREREQUISITES.format(e.name))
+
+# ==== CONFIG ====
 
 args = parser.parse_args()
 

--- a/diff.py
+++ b/diff.py
@@ -27,6 +27,10 @@ start_argument = parser.add_argument("start", help="Function name or address to 
 if argcomplete:
     def complete_symbol(**kwargs):
         prefix = kwargs["prefix"]
+        if prefix == "":
+            # skip reading the map file, which would
+            # result in a lot of useless completions
+            return []
         parsed_args = kwargs["parsed_args"]
         config = {}
         diff_settings.apply(config, parsed_args)

--- a/diff.py
+++ b/diff.py
@@ -36,22 +36,22 @@ if argcomplete:
         completes = []
         with open(mapfile) as f:
             data = f.read()
-            if data.startswith(prefix):
-                endPos = data.find(" ")
-                completes.append(data if endPos == -1 else data[:endPos])
+            # assume symbols are prefixed by a space character
             search = f" {prefix}"
             pos = data.find(search)
             while pos != -1:
                 # skip the space character in the search string
                 pos += 1
-                endPos = data.find(" ", pos)
+                # assume symbols are suffixed by either a space
+                # character or a (unix-style) line return
+                endPos = min(data.find(" ", pos), data.find("\n", pos))
                 if endPos == -1:
                     match = data[pos:]
                     pos = -1
                 else:
                     match = data[pos:endPos]
                     pos = data.find(search, endPos)
-                completes.append(match.strip())
+                completes.append(match)
         return completes
     start_argument.completer = complete_symbol
 

--- a/diff.py
+++ b/diff.py
@@ -48,7 +48,14 @@ if argcomplete:
                 pos += 1
                 # assume symbols are suffixed by either a space
                 # character or a (unix-style) line return
-                endPos = min(data.find(" ", pos), data.find("\n", pos))
+                spacePos = data.find(" ", pos)
+                lineReturnPos = data.find("\n", pos)
+                if lineReturnPos == -1:
+                    endPos = spacePos
+                elif spacePos == -1:
+                    endPos = lineReturnPos
+                else:
+                    endPos = min(spacePos, lineReturnPos)
                 if endPos == -1:
                     match = data[pos:]
                     pos = -1


### PR DESCRIPTION
The first commit actually adds tab-completion, the second does reordering for performance.

Soft requirement: `pip install argcomplete` (does nothing different compared to current master if argcomplete isn't available)
See [the first commit](https://github.com/simonlindholm/asm-differ/commit/88e64aa81e8d3a1f37d73d4e33af0b9ba219a5ca)

How the script is called matters, if tab completion has been setup for `./diff.py` using something else like `../asm-differ/diff.py` won't allow tab-completion. I think `argcomplete` intends to have the scripts in the path.

Symbol detection is very rough (a somewhat equivalent regex would be `(?: |^)([^ \n]+)(?: |$)` maybe?), but it seems ok