### PR TITLE
Add option to use a custom make target

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1533,6 +1533,10 @@ def main() -> None:
     else:
         make_target, basecmd, mycmd = dump_binary()
 
+    map_build_target_fn = getattr(diff_settings, "map_build_target", None)
+    if map_build_target_fn:
+        make_target = map_build_target_fn(make_target=make_target)
+
     if args.write_asm is not None:
         mydump = run_objdump(mycmd)
         with open(args.write_asm, "w") as f:


### PR DESCRIPTION
For some build systems, the name of the target that generates the main
executable does not match the path to the ELF file, especially when
the ELF is in a separate build directory.