### PR TITLE
Clear Windows Terminal buffer before diffing

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1446,6 +1446,12 @@ class Display:
             header_lines = [header] if header else []
             output = "\n".join(header_lines + diff_lines[args.skip_lines :])
 
+        # Windows Terminal does not handle buffers properly
+        # Janky hack to clear its scrollback buffer until it's fixed
+        clear_proc = subprocess.Popen(
+            ["echo", "-en", "\"\e[3J\""]
+        )
+
         # Pipe the output through 'tail' and only then to less, to ensure the
         # write call doesn't block. ('tail' has to buffer all its input before
         # it starts writing.) This also means we don't have to deal with pipe


### PR DESCRIPTION
Windows Terminal doesn't clear its buffers properly and scrolling is all screwy. Diffs don't open with new buffers, and it's possible to scroll up to view previous console output. This workaround forces a clear which clears that out. If there's a better way/place to do this, let me know.