### PR TITLE
Add support for HTML output

### DIFF
--- a/diff-stylesheet.css
+++ b/diff-stylesheet.css
@@ -1,0 +1,64 @@
+table.diff {
+    border: none;
+    font-family: Monospace;
+    white-space: pre;
+}
+.immediate {
+    color: lightblue;
+}
+.stack {
+    color: yellow;
+}
+.register {
+    color: yellow;
+}
+.delay-slot {
+    font-weight: bold;
+    color: gray;
+}
+.diff-change {
+    color: lightblue;
+}
+.diff-add {
+    color: green;
+}
+.diff-remove {
+    color: red;
+}
+.source-filename {
+    font-weight: bold;
+}
+.source-function {
+    font-weight: bold;
+    text-decoration: underline;
+}
+.source-other {
+    font-style: italic;
+}
+.color-rotation-0 {
+    color: magenta;
+}
+.color-rotation-1 {
+    color: cyan;
+}
+.color-rotation-2 {
+    color: green;
+}
+.color-rotation-3 {
+    color: red;
+}
+.color-rotation-4 {
+    color: yellow;
+}
+.color-rotation-5 {
+    color: pink;
+}
+.color-rotation-6 {
+    color: blue;
+}
+.color-rotation-7 {
+    color: lime;
+}
+.color-rotation-8 {
+    color: gray;
+}

--- a/diff.py
+++ b/diff.py
@@ -540,7 +540,14 @@ def search_map_file(
             return cands[0]
     elif project.map_format == "mw":
         #                                         ram   elf rom                                                       object name
-        find = re.findall(re.compile(r'  \S+ \S+ (\S+) (\S+)  . ' + fn_name + r'(?: \(entry of \.(?:init|text)\))? \t(\S+)'), contents)
+        find = re.findall(
+            re.compile(
+                r"  \S+ \S+ (\S+) (\S+)  . "
+                + fn_name
+                + r"(?: \(entry of \.(?:init|text)\))? \t(\S+)"
+            ),
+            contents,
+        )
         if len(find) > 1:
             fail(f"Found multiple occurrences of function {fn_name} in map file.")
         if len(find) == 1:
@@ -556,7 +563,9 @@ def search_map_file(
             ]
             if len(objfiles) > 1:
                 all_objects = "\n".join(objfiles)
-                fail(f"Found multiple objects of the same name {objname} in {project.mw_build_dir}, cannot determine which to diff against: \n{all_objects}")
+                fail(
+                    f"Found multiple objects of the same name {objname} in {project.mw_build_dir}, cannot determine which to diff against: \n{all_objects}"
+                )
             if len(objfiles) == 1:
                 objfile = objfiles[0]
                 # TODO Currently the ram-rom conversion only works for diffing ELF
@@ -601,7 +610,11 @@ def dump_elf(
     return (
         project.myimg,
         (objdump_flags + flags1, project.baseimg, None),
-        (objdump_flags + flags2 + maybe_get_objdump_source_flags(config), project.myimg, None),
+        (
+            objdump_flags + flags2 + maybe_get_objdump_source_flags(config),
+            project.myimg,
+            None,
+        ),
     )
 
 
@@ -1293,12 +1306,21 @@ def do_diff(basedump: str, mydump: str, config: Config) -> List[OutputLine]:
                     out2, branch2 = split_off_branch(line2.original)
                 branchless1 = out1
                 branchless2 = out2
-                out1, out2 = color_fields(arch.re_imm, out1, out2, lambda s: f"{Fore.LIGHTBLUE_EX}{s}{Style.RESET_ALL}")
+                out1, out2 = color_fields(
+                    arch.re_imm,
+                    out1,
+                    out2,
+                    lambda s: f"{Fore.LIGHTBLUE_EX}{s}{Style.RESET_ALL}",
+                )
 
                 same_relative_target = False
                 if line1.branch_target is not None and line2.branch_target is not None:
-                    relative_target1 = eval_line_num(line1.branch_target) - eval_line_num(line1.line_num)
-                    relative_target2 = eval_line_num(line2.branch_target) - eval_line_num(line2.line_num)
+                    relative_target1 = eval_line_num(
+                        line1.branch_target
+                    ) - eval_line_num(line1.line_num)
+                    relative_target2 = eval_line_num(
+                        line2.branch_target
+                    ) - eval_line_num(line2.line_num)
                     same_relative_target = relative_target1 == relative_target2
 
                 if not same_relative_target:
@@ -1306,14 +1328,20 @@ def do_diff(basedump: str, mydump: str, config: Config) -> List[OutputLine]:
 
                 out1 += branch1
                 out2 += branch2
-                if normalize_imms(branchless1, arch) == normalize_imms(branchless2, arch):
+                if normalize_imms(branchless1, arch) == normalize_imms(
+                    branchless2, arch
+                ):
                     if not same_relative_target:
                         # only imms differences
                         sym_color = Fore.LIGHTBLUE_EX
                         line_prefix = "i"
                 else:
-                    out1, out2 = color_fields(arch.re_sprel, out1, out2, sc3.color_symbol, sc4.color_symbol)
-                    if normalize_stack(branchless1, arch) == normalize_stack(branchless2, arch):
+                    out1, out2 = color_fields(
+                        arch.re_sprel, out1, out2, sc3.color_symbol, sc4.color_symbol
+                    )
+                    if normalize_stack(branchless1, arch) == normalize_stack(
+                        branchless2, arch
+                    ):
                         # only stack differences (luckily stack and imm
                         # differences can't be combined in MIPS, so we
                         # don't have to think about that case)
@@ -1321,7 +1349,9 @@ def do_diff(basedump: str, mydump: str, config: Config) -> List[OutputLine]:
                         line_prefix = "s"
                     else:
                         # regs differences and maybe imms as well
-                        out1, out2 = color_fields(arch.re_reg, out1, out2, sc1.color_symbol, sc2.color_symbol)
+                        out1, out2 = color_fields(
+                            arch.re_reg, out1, out2, sc1.color_symbol, sc2.color_symbol
+                        )
                         line_color1 = line_color2 = sym_color = Fore.YELLOW
                         line_prefix = "r"
         elif line1 and line2:
@@ -1678,9 +1708,13 @@ def main() -> None:
         fail("Threeway diffing requires -w.")
 
     if args.diff_elf_symbol:
-        make_target, basecmd, mycmd = dump_elf(args.start, args.end, args.diff_elf_symbol, config, project)
+        make_target, basecmd, mycmd = dump_elf(
+            args.start, args.end, args.diff_elf_symbol, config, project
+        )
     elif config.diff_obj:
-        make_target, basecmd, mycmd = dump_objfile(args.start, args.end, config, project)
+        make_target, basecmd, mycmd = dump_objfile(
+            args.start, args.end, config, project
+        )
     else:
         make_target, basecmd, mycmd = dump_binary(args.start, args.end, config, project)
 

--- a/diff.py
+++ b/diff.py
@@ -1787,19 +1787,15 @@ class Display:
 
     def run_diff(self) -> str:
         if self.emsg is not None:
-            output = self.emsg
-        else:
-            diff_output = do_diff(self.basedump, self.mydump, self.config)
-            last_diff_output = self.last_diff_output or diff_output
-            if self.config.threeway != "base" or not self.last_diff_output:
-                self.last_diff_output = diff_output
-            header, diff_lines = format_diff(last_diff_output, diff_output, self.config)
-            header_lines = [header] if header else []
-            return self.config.formatter.table(
-                header, diff_lines[self.config.skip_lines :]
-            )
-            output = "\n".join(header_lines + diff_lines[self.config.skip_lines :])
-        return output
+            return self.emsg
+
+        diff_output = do_diff(self.basedump, self.mydump, self.config)
+        last_diff_output = self.last_diff_output or diff_output
+        if self.config.threeway != "base" or not self.last_diff_output:
+            self.last_diff_output = diff_output
+        header, diff_lines = format_diff(last_diff_output, diff_output, self.config)
+        header_lines = [header] if header else []
+        return self.config.formatter.table(header, diff_lines[self.config.skip_lines :])
 
     def run_less(self) -> "Tuple[subprocess.Popen[bytes], subprocess.Popen[bytes]]":
         output = self.run_diff()

--- a/diff.py
+++ b/diff.py
@@ -499,7 +499,7 @@ class Text:
         # Use Formatter.apply(...) instead
         return NotImplemented
 
-    def __eq__(self) -> str:
+    def __eq__(self, other: object) -> bool:
         return NotImplemented
 
     def __add__(self, other: Union["Text", str]) -> "Text":
@@ -614,7 +614,6 @@ class HtmlFormatter(Formatter):
     ) -> str:
         if header:
             lines = [header] + lines
-        # TODO: Make a prettier stylesheet (maybe include it externally)
         output = "<table class='diff'>\n"
         for line in lines:
             output += "    <tr>"

--- a/diff.py
+++ b/diff.py
@@ -492,12 +492,15 @@ class Text:
     def plain(self) -> str:
         return "".join(s for s, f in self.segments)
 
+    def __repr__(self) -> str:
+        return f"<Text: {self.plain()!r}>"
+
     def __str__(self) -> str:
         # Use Formatter.apply(...) instead
         return NotImplemented
 
-    def __repr__(self) -> str:
-        return f"<Text: {self.plain()!r}>"
+    def __eq__(self) -> str:
+        return NotImplemented
 
     def __add__(self, other: Union["Text", str]) -> "Text":
         if isinstance(other, str):

--- a/diff.py
+++ b/diff.py
@@ -615,75 +615,7 @@ class HtmlFormatter(Formatter):
         if header:
             lines = [header] + lines
         # TODO: Make a prettier stylesheet (maybe include it externally)
-        output = """
-<style>
-table.diff {
-    border: none;
-    font-family: Monospace;
-    white-space: pre;
-}
-table.diff .immediate {
-    color: lightblue;
-}
-table.diff .stack {
-    color: yellow;
-}
-table.diff .register {
-    color: yellow;
-}
-table.diff .delay-slot {
-    font-weight: bold;
-    color: gray;
-}
-table.diff .diff-change {
-    color: lightblue;
-}
-table.diff .diff-add {
-    color: green;
-}
-table.diff .diff-remove {
-    color: red;
-}
-table.diff .source-filename {
-    font-weight: bold;
-}
-table.diff .source-function {
-    font-weight: bold;
-    text-decoration: underline;
-}
-table.diff .source-other {
-    font-style: italic;
-}
-table.diff .color-rotation-0 {
-    color: magenta;
-}
-table.diff .color-rotation-1 {
-    color: cyan;
-}
-table.diff .color-rotation-2 {
-    color: green;
-}
-table.diff .color-rotation-3 {
-    color: red;
-}
-table.diff .color-rotation-4 {
-    color: yellow;
-}
-table.diff .color-rotation-5 {
-    color: pink;
-}
-table.diff .color-rotation-6 {
-    color: blue;
-}
-table.diff .color-rotation-7 {
-    color: lime;
-}
-table.diff .color-rotation-8 {
-    color: gray;
-}
-</style>
-"""
-        output += "<table class='diff'>\n"
+        output = "<table class='diff'>\n"
         for line in lines:
             output += "    <tr>"
             for cell in line:

--- a/diff_settings.py
+++ b/diff_settings.py
@@ -3,8 +3,8 @@ def apply(config, args):
     config["myimg"] = "source.bin"
     config["mapfile"] = "build.map"
     config["source_directories"] = ["."]
-    #config["arch"] = "mips"
-    #config["map_format"] = "gnu" # gnu or mw
-    #config["mw_build_dir"] = "build/" # only needed for mw map format
-    #config["makeflags"] = []
-    #config["objdump_executable"] = ""
+    # config["arch"] = "mips"
+    # config["map_format"] = "gnu" # gnu or mw
+    # config["mw_build_dir"] = "build/" # only needed for mw map format
+    # config["makeflags"] = []
+    # config["objdump_executable"] = ""


### PR DESCRIPTION
Add the `--format` argument for specifying the output style/format:
- `color` is the default option, the existing state
- `plain` also uses the terminal, but without any ANSI escape codes/styles
- `html` outputs an HTML document fragment (and disables the pager)

The stylesheet I have is pretty bad, but it should be very easy to plug in different styles (e.g. dark mode). It's mostly a 1-1 translation, but the colors should probably be tweaked for a light background.

In a future PR, it'd be nice if everywhere `COLOR_ROTATION` formatting is used, we could mark up the HTML with metadata about the symbol names. This could make it possible to add interactivity with JS?

- [x] ~Todo~: need to look closely to ensure that all untrusted strings are escaped
- [x] ~Todo~: test with `--elf`/`--source` (is there a project where these work?)