### PR TITLE
Expose highlighted branch/reg details in an HTML attribute

### DIFF
--- a/diff-stylesheet.css
+++ b/diff-stylesheet.css
@@ -35,30 +35,30 @@ table.diff {
 .source-other {
     font-style: italic;
 }
-.color-rotation-0 {
+.rotation-0 {
     color: magenta;
 }
-.color-rotation-1 {
+.rotation-1 {
     color: cyan;
 }
-.color-rotation-2 {
+.rotation-2 {
     color: green;
 }
-.color-rotation-3 {
+.rotation-3 {
     color: red;
 }
-.color-rotation-4 {
+.rotation-4 {
     color: yellow;
 }
-.color-rotation-5 {
+.rotation-5 {
     color: pink;
 }
-.color-rotation-6 {
+.rotation-6 {
     color: blue;
 }
-.color-rotation-7 {
+.rotation-7 {
     color: lime;
 }
-.color-rotation-8 {
+.rotation-8 {
     color: gray;
 }


### PR DESCRIPTION
This PR doesn't change the visible output, but should make it straightforward to improve the HTML diff. Should be easier to add new colors, incorporate `<a>`s, or write JS to make it more interactive.

I don't love having separate `BasicFormat`/`RotationFormat` types, but I couldn't find a better way to emulate a sum type with modern Python. (Happy to hear a better suggestion!)

I also think the naming/format of the `data-rotation` is a bit arbitrary, I mostly wanted to make sure that the information was plumbed through without being excessively verbose.
