### PR TITLE
Fix --watch not working with files in top directory

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1737,7 +1737,7 @@ def debounced_fs_watch(
 
         def should_notify(self, path: str) -> bool:
             for target in self.file_targets:
-                if path == target:
+                if os.path.samefile(path, target):
                     return True
             if config.make and any(
                 path.endswith(suffix) for suffix in project.source_extensions

--- a/diff.py
+++ b/diff.py
@@ -1737,7 +1737,7 @@ def debounced_fs_watch(
 
         def should_notify(self, path: str) -> bool:
             for target in self.file_targets:
-                if os.path.samefile(path, target):
+                if os.path.normpath(path) == target:
                     return True
             if config.make and any(
                 path.endswith(suffix) for suffix in project.source_extensions
@@ -1759,7 +1759,7 @@ def debounced_fs_watch(
             if os.path.isdir(target):
                 observer.schedule(event_handler, target, recursive=True)
             else:
-                file_targets.append(target)
+                file_targets.append(os.path.normpath(target))
                 target = os.path.dirname(target) or "."
                 if target not in observed:
                     observed.add(target)


### PR DESCRIPTION
I'm tinkering with diff.py and for testing I'm using target.bin and source.bin files in the same directory as diff.py (running with `./diff.py --watch 0`)
--watch doesn't see changes made to source.bin because `WatchEventHandler#changed` receives "./source.bin" which isn't in the watched files list `file_targets == ['source.bin']`
I fixed it by changing `if path == target:` to `if os.path.samefile(path, target):` in `WatchEventHandler#should_notify`, I thought that was the cleanest