### PR TITLE
Add --source-old-binutils, like --source but works with binutils < 2.33

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -793,7 +793,7 @@ def run_objdump(cmd: ObjdumpCommand, config: Config, project: ProjectSettings) -
         print(e.stdout)
         print(e.stderr)
         if "unrecognized option '--source-comment" in e.stderr:
-            print("** Try using --source-old-binutils instead of --source **")
+            fail("** Try using --source-old-binutils instead of --source **")
         raise e
 
     if restrict is not None:

--- a/diff.py
+++ b/diff.py
@@ -1636,11 +1636,10 @@ def do_diff(basedump: str, mydump: str, config: Config) -> List[OutputLine]:
         if line2:
             for source_line in line2.source_lines:
                 line_format = BasicFormat.SOURCE_OTHER
-                # File names and function names
-                if source_line and source_line[0] != "│":
-                    line_format = BasicFormat.SOURCE_FILENAME
-                    # Function names
-                    if source_line.endswith("():"):
+                if config.source_old_binutils:
+                    if source_line and re.fullmatch(".*\.c(?:pp)?:\d+", source_line):
+                        line_format = BasicFormat.SOURCE_FILENAME
+                    elif source_line and source_line.endswith("():"):
                         line_format = BasicFormat.SOURCE_FUNCTION
                         try:
                             source_line = cxxfilt.demangle(
@@ -1648,6 +1647,19 @@ def do_diff(basedump: str, mydump: str, config: Config) -> List[OutputLine]:
                             )
                         except:
                             pass
+                else:
+                    # File names and function names
+                    if source_line and source_line[0] != "│":
+                        line_format = BasicFormat.SOURCE_FILENAME
+                        # Function names
+                        if source_line.endswith("():"):
+                            line_format = BasicFormat.SOURCE_FUNCTION
+                            try:
+                                source_line = cxxfilt.demangle(
+                                    source_line[:-3], external_only=False
+                                )
+                            except:
+                                pass
                 output.append(
                     OutputLine(
                         None,


### PR DESCRIPTION
Using `--source` with diff.py in main relies on the objdump `--source-comment` option which apparently was only added in binutils 2.33+

This adds `--source-old-binutils` which makes do without `--source-comment` at the cost of using a regex to match source lines (hopefully it won't do (many) mistakes) to achieve what `--source` does with binutils 2.33+

I also added a rough check for objdump failing because of `--source-comment` to suggest using `--source-old-binutils`