### PR TITLE
Dim source filename and function names (fixes style regression)

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -578,9 +578,9 @@ class AnsiFormatter(Formatter):
         BasicFormat.DIFF_CHANGE: Fore.LIGHTBLUE_EX,
         BasicFormat.DIFF_ADD: Fore.GREEN,
         BasicFormat.DIFF_REMOVE: Fore.RED,
-        BasicFormat.SOURCE_FILENAME: Style.BRIGHT,
-        # Underline (not in colorama) + bright
-        BasicFormat.SOURCE_FUNCTION: Style.BRIGHT + "\u001b[4m",
+        BasicFormat.SOURCE_FILENAME: Style.DIM + Style.BRIGHT,
+        # Underline (not in colorama) + bright + dim
+        BasicFormat.SOURCE_FUNCTION: Style.DIM + Style.BRIGHT + "\u001b[4m",
         BasicFormat.SOURCE_OTHER: Style.DIM,
     }
 


### PR DESCRIPTION
Source file paths and function names should be dimmed to make the diff
easier to read. This used to be the case but the dimming style was
accidentally removed when the styling code was refactored.