### PR TITLE
Add a short alias for --source (-c)

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -117,11 +117,13 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--source",
+        "-c",
         action="store_true",
         help="Show source code (if possible). Only works with -o and -e.",
     )
     parser.add_argument(
         "--source-old-binutils",
+        "-C",
         action="store_true",
         help="Tweak --source handling to make it work with binutils < 2.33. Implies --source.",
     )


### PR DESCRIPTION
After the addition of --source-old-binutils, passing --source now
requires writing the option in full. --so and other shorthands
do not work anymore because they are now ambiguous.

For the sake of convenience, this adds -c as an alias for --source
(c for sourCe or C/C++, I guess...)

~~We may want to add an alias for --source-old-binutils as well but
I don't know what alias would be best. -C? (Maybe it's best to
let people who actually use that option decide.)~~

Similarly, added -C as a alias for --source-old-binutils.