### PR TITLE
Fix help message typos

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -119,7 +119,7 @@ if __name__ == "__main__":
         "--source",
         "-c",
         action="store_true",
-        help="Show source code (if possible). Only works with -o and -e.",
+        help="Show source code (if possible). Only works with -o or -e.",
     )
     parser.add_argument(
         "--source-old-binutils",
@@ -130,7 +130,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--inlines",
         action="store_true",
-        help="Show inline function calls (if possible). Only works with -o and -e.",
+        help="Show inline function calls (if possible). Only works with -o or -e.",
     )
     parser.add_argument(
         "--base-asm",


### PR DESCRIPTION
As discussed in Discord, `-e` and `-o` are mutually exclusive, so it can cause confusion to "and them" together in the help message.