### PR TITLE
Add source line numbers to output with `-L`

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1490,9 +1490,9 @@ def process(lines: List[str], config: Config) -> List[Line]:
 
         # This regex is conservative, and assumes the file path does not contain "weird"
         # characters like colons, tabs, or angle brackets.
-        if row and re.match(r"^[^ \t<>:][^\t<>:]*:[0-9]+$", row):
-            source_filename, _, num = row.rpartition(":")
-            source_line_num = int(num)
+        if row and re.match(r"^[^ \t<>:][^\t<>:]*:[0-9]+( \(discriminator [0-9]+\))?$", row):
+            source_filename, _, tail = row.rpartition(":")
+            source_line_num = int(tail.partition(" ")[0])
             continue
 
         if config.source and not config.source_old_binutils and (row and row[0] != " "):

--- a/diff.py
+++ b/diff.py
@@ -1490,7 +1490,9 @@ def process(lines: List[str], config: Config) -> List[Line]:
 
         # This regex is conservative, and assumes the file path does not contain "weird"
         # characters like colons, tabs, or angle brackets.
-        if row and re.match(r"^[^ \t<>:][^\t<>:]*:[0-9]+( \(discriminator [0-9]+\))?$", row):
+        if row and re.match(
+            r"^[^ \t<>:][^\t<>:]*:[0-9]+( \(discriminator [0-9]+\))?$", row
+        ):
             source_filename, _, tail = row.rpartition(":")
             source_line_num = int(tail.partition(" ")[0])
             continue
@@ -2051,7 +2053,12 @@ def do_diff(basedump: str, mydump: str, config: Config) -> Diff:
 
         if config.show_line_numbers:
             if line2 and line2.source_line_num is not None:
-                num2 = Text(f"{line2.source_line_num:5}", BasicFormat.SOURCE_LINE_NUM)
+                num_color = (
+                    BasicFormat.SOURCE_LINE_NUM
+                    if sym_color == BasicFormat.NONE
+                    else sym_color
+                )
+                num2 = Text(f"{line2.source_line_num:5}", num_color)
             else:
                 num2 = Text(" " * 5)
         else:


### PR DESCRIPTION
- New command line option: `-L`/`--line-numbers`
    - Line numbers are *always* included in JSON output
- `objdump` has supported `-l`/`--line-numbers` since at least 2000, so it shouldn't need a warning about binutils version.
- When enabled, line numbers are added to the "current" & "previous" columns after the "line prefix"
   - Assumes that line numbers are *usually* less than 10000 (otherwise it will run into the line prefix)
   - Happy to reorganize the UI or put this info somewhere else.

Example from MM, in my terminal (`diff.py -omwbL -U2 ...`) (edit: now based on `4427a0c`)
![2021-09-01-165333_1802x503_scrot](https://user-images.githubusercontent.com/113075/131743709-78175fca-770b-456a-9719-ec686bfde4f1.png)


