### PR TITLE
Annotate data pool symbols inline for ARM32

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1834,7 +1834,7 @@ def process(dump: str, config: Config) -> List[Line]:
             )
             break
 
-        if not re.match(r"^ +[0-9a-f]+:\t", row):
+        if not re.match(r"^\s+[0-9a-f]+:\s+", row):
             # This regex is conservative, and assumes the file path does not contain "weird"
             # characters like colons, tabs, or angle brackets.
             if re.match(

--- a/diff.py
+++ b/diff.py
@@ -1343,7 +1343,7 @@ class RelocationProcessorMIPS(RelocationProcessor):
         # Remove previous line in order to replace it with reloc-processed line
         prevLineIdx = len(lines) - 1
         prevLine = lines.pop(prevLineIdx)
-        return self._process_mips_reloc(curLine, prevLine, self.config.arch)
+        return self._process_mips_reloc(curLine, prevLine.original, self.config.arch)
 
     def _process_mips_reloc(self, row: str, prev: str, arch: "ArchSettings") -> str:
         before, imm, after = parse_relocated_line(prev)
@@ -1389,7 +1389,7 @@ class RelocationProcessorPPC(RelocationProcessor):
         # Remove previous line in order to replace it with reloc-processed line
         prevLineIdx = len(lines) - 1
         prevLine = lines.pop(prevLineIdx)
-        return self._process_ppc_reloc(self, curLine, prevLine)
+        return self._process_ppc_reloc(curLine, prevLine.original)
 
     def _process_ppc_reloc(self, row: str, prev: str) -> str:
         assert any(


### PR DESCRIPTION
References data pool symbols inline for ARM32. Displays the symbol and the address (parenthesized). Here is an example snippet (see [full diff](https://gist.github.com/abaresk/33b611ac8fb35f7976dc43d35c86689b)):

```
b4a:    ldr     r2, [pc, #0x1c] ; =gBlockRecvBuffer (b68)
...                              
b68:    .word   gBlockRecvBuffer   
```

Created a `RelocationProcessor` class which each architecture implements. If an asm line matches the architecture's `re_reloc` regex, `reloc_processor.process()` gets called on that line. This makes it easier to trigger on the relocation sentinel.

Moved existing relocation functionality for non-ARM32 architectures into their own sub-classes.

Created a `PostProcessor` class, which is called at the end of `process()`. This is useful if you need access to all the output lines to perform any processing. For ARM32, objdump only outputs the addresses of data pool symbols. So in `PostProcessorARM32`, we dereference the symbol at the given data pool address. E.g. objdump output:

```
00000adc <Task_LinkContest_CommunicateTurnOrder>:
 ...
 b4a:   4a07            ldr     r2, [pc, #28]   ; (b68 <Task_LinkContest_CommunicateTurnOrder+0x8c>)
 b4c:   1889            adds    r1, r1, r2
 ...
 b68:   00000000        .word   0x00000000
                        b68: R_ARM_ABS32        gBlockRecvBuffer
``` 

TESTS = [ARM32](https://gist.github.com/abaresk/33b611ac8fb35f7976dc43d35c86689b) (new functionality), [PPC](https://gist.github.com/abaresk/df4f30ebc693c035040b5c7d377eda79) (unchanged), [MIPS](https://gist.github.com/abaresk/7a0cdb31d4e73b64f689107595b108d6) (unchanged), AARCH64 doesn't process relocations