### PR TITLE
Fix ignore_addr_diffs with AArch64 BL instructions

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1485,7 +1485,6 @@ ARM32_BRANCH_INSTRUCTIONS = {
 }
 
 AARCH64_BRANCH_INSTRUCTIONS = {
-    "bl",
     "b",
     "b.eq",
     "b.ne",
@@ -1583,7 +1582,7 @@ AARCH64_SETTINGS = ArchSettings(
     re_large_imm=re.compile(r"-?[1-9][0-9]{2,}|-?0x[0-9a-f]{3,}"),
     re_imm=re.compile(r"(?<!sp, )#-?(0x[0-9a-fA-F]+|[0-9]+)\b"),
     branch_instructions=AARCH64_BRANCH_INSTRUCTIONS,
-    instructions_with_address_immediates=AARCH64_BRANCH_INSTRUCTIONS.union({"adrp"}),
+    instructions_with_address_immediates=AARCH64_BRANCH_INSTRUCTIONS.union({"bl", "adrp"}),
     difference_normalizer=DifferenceNormalizerAArch64,
 )
 


### PR DESCRIPTION
> [15/09/2021 00:29] simonlindholm: I think the fix may be to remove "bl" from AARCH64_BRANCH_INSTRUCTIONS, but keep it in instructions_with_address_immediates

(I've verified that this does fix the issue)