### PR TITLE
Ignore .mwcats.text elf section

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1198,6 +1198,9 @@ def parse_elf_data_references(data: bytes) -> List[Tuple[int, int, str]]:
                 # Skip .text -> .text references
                 continue
             sec_name = sec_names[s.sh_info].decode("latin1")
+            if sec_name == ".mwcats.text":
+                # Skip Metrowerks CATS Utility section
+                continue
             sec_base = sections[s.sh_info].sh_offset
             for i in range(0, s.sh_size, s.sh_entsize):
                 if s.sh_type == SHT_REL:
@@ -1357,7 +1360,7 @@ class AsmProcessor:
 
     def _normalize_arch_specific(self, mnemonic: str, row: str) -> str:
         return row
-    
+
     def post_process(self, lines: List["Line"]) -> None:
         return
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22226349/145108551-33df28b6-3c5e-4137-9436-b1e6215e54eb.png)

Went with the name because I couldn't see anything obviously unique about the section:
```
backend_1   | sec_name .mwcats.text
backend_1   | sh_name 20
backend_1   | sh_type 4
backend_1   | sh_flags 0
backend_1   | sh_addr 0
backend_1   | sh_offset 64
backend_1   | sh_size 12
backend_1   | sh_link 4
backend_1   | sh_info 2
backend_1   | sh_addralign 4
backend_1   | sh_entsize 12
```