### PR TITLE
Fix data pool lookup errors

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1333,11 +1333,6 @@ def dump_binary(
         (objdump_flags + flags2, project.myimg, None),
     )
 
-DATA_POOL_PLACEHOLDER = "DATA_POOL_PLACEHOLDER-OFFSET_{}"
-DATA_POOL_PLACEHOLDER_PATTERN = re.compile(
-    r"DATA_POOL_PLACEHOLDER-OFFSET_([a-zA-z0-9]+)"
-)
-
 # Example: "ldr r4, [pc, #56]    ; (4c <AddCoins+0x4c>)"
 ARM32_LOAD_POOL_PATTERN = r"(ldr\s+r([0-9]|1[0-3]),\s+\[pc,.*;\s*)(\([a-fA-F0-9]+.*\))"
 
@@ -1463,37 +1458,21 @@ class AsmProcessorARM32(AsmProcessor):
 
     def _normalize_data_pool(self, row: str) -> str:
         pool_match = re.search(ARM32_LOAD_POOL_PATTERN, row)
-        if pool_match:
-            offset = pool_match.group(3).split(" ")[0][1:]
-            repl = DATA_POOL_PLACEHOLDER.format(offset)
-            return pool_match.group(1) + repl
-        return row
+        return pool_match.group(1) if pool_match else row
 
     def post_process(self, lines: List["Line"]) -> None:
         lines_by_line_number = {}
         for line in lines:
             lines_by_line_number[line.line_num] = line
         for line in lines:
-            reloc_match = re.search(
-                DATA_POOL_PLACEHOLDER_PATTERN, line.normalized_original
-            )
-            if reloc_match is None:
+            if line.data_pool_addr is None:
                 continue
 
-            # Get value at relocation
-            reloc = reloc_match.group(0)
-            line_number = re.search(
-                DATA_POOL_PLACEHOLDER_PATTERN, reloc).group(1)
-            line_original = lines_by_line_number[int(line_number, 16)].original
+            # Add data symbol and its address to the line.
+            line_original = lines_by_line_number[line.data_pool_addr].original
             value = line_original.split()[1]
-
-            # Replace relocation placeholder with value
-            replaced = re.sub(
-                DATA_POOL_PLACEHOLDER_PATTERN,
-                f"={value} ({line_number})",
-                line.normalized_original,
-            )
-            line.original = replaced
+            addr = "{:x}".format(line.data_pool_addr)
+            line.original = line.normalized_original + f"={value} ({addr})"
 
 
 class AsmProcessorAArch64(AsmProcessor):
@@ -1798,6 +1777,7 @@ class Line:
     scorable_line: str
     line_num: Optional[int] = None
     branch_target: Optional[int] = None
+    data_pool_addr: Optional[int] = None
     source_filename: Optional[str] = None
     source_line_num: Optional[int] = None
     source_lines: List[str] = field(default_factory=list)
@@ -1858,6 +1838,14 @@ def process(dump: str, config: Config) -> List[Line]:
                 source_line_num = int(tail.partition(" ")[0])
             source_lines.append(row)
             continue
+
+        # If the instructions loads a data pool symbol, extract the address of
+        # the symbol.
+        data_pool_addr = None
+        pool_match = re.search(ARM32_LOAD_POOL_PATTERN, row)
+        if pool_match:
+            offset = pool_match.group(3).split(" ")[0][1:]
+            data_pool_addr = int(offset, 16)
 
         m_comment = re.search(arch.re_comment, row)
         comment = m_comment[0] if m_comment else None
@@ -1949,6 +1937,7 @@ def process(dump: str, config: Config) -> List[Line]:
                 scorable_line=scorable_line,
                 line_num=line_num,
                 branch_target=branch_target,
+                data_pool_addr=data_pool_addr,
                 source_filename=source_filename,
                 source_line_num=source_line_num,
                 source_lines=source_lines,


### PR DESCRIPTION
Fixes dictionary key lookup errors that occur when trying to dereference a data symbol (see example [scratch](https://decomp.me/scratch/XRuTB)). The root cause of the issue was [these lines](https://github.com/simonlindholm/asm-differ/blob/89df9d720d996267095edab0f17dc7026744e83e/diff.py#L1894-L1895), which tried to hexify the data symbol address even though objdump already dumps it as a hex value. As a result, it sometimes would try to lookup the symbol at an address that doesn't exist and crash.

Fixed this by extracting the data symbol address while parsing the asm lines and storing it in the `Line` data struct. Also removed the code for temporarily annotating a `DATA_POOL_PLACEHOLDER`, as this data is now directly available in the `Line`.

See scratch with fix applied:
<img width="1280" alt="Screen Shot 2022-01-11 at 9 58 38 AM" src="https://user-images.githubusercontent.com/46002898/148966638-54661c78-893b-4f44-9c3c-fe36fa66790d.png">
