### PR TITLE
Fix the AArch64 register regex for FP regs followed by data width

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1694,9 +1694,10 @@ AARCH64_SETTINGS = ArchSettings(
     name="aarch64",
     re_int=re.compile(r"[0-9]+"),
     re_comment=re.compile(r"(<.*?>|//.*$)"),
-    # GPRs and FP registers: X0-X30, W0-W30, [DSHQ]0..31
+    # GPRs and FP registers: X0-X30, W0-W30, [BHSDVQ]0..31
+    # (FP registers may be followed by data width and number of elements, e.g. V0.4S)
     # The zero registers and SP should not be in this list.
-    re_reg=re.compile(r"\$?\b([dshq][12]?[0-9]|[dshq]3[01]|[xw][12]?[0-9]|[xw]30)\b"),
+    re_reg=re.compile(r"\$?\b([bhsdvq][12]?[0-9](\.\d\d?[bhsdvq])?|[bhsdvq]3[01](\.\d\d?[bhsdvq])?|[xw][12]?[0-9]|[xw]30)\b"),
     re_sprel=re.compile(r"sp, #-?(0x[0-9a-fA-F]+|[0-9]+)\b"),
     re_large_imm=re.compile(r"-?[1-9][0-9]{2,}|-?0x[0-9a-f]{3,}"),
     re_imm=re.compile(r"(?<!sp, )#-?(0x[0-9a-fA-F]+|[0-9]+)\b"),

--- a/diff.py
+++ b/diff.py
@@ -1697,7 +1697,7 @@ AARCH64_SETTINGS = ArchSettings(
     # GPRs and FP registers: X0-X30, W0-W30, [BHSDVQ]0..31
     # (FP registers may be followed by data width and number of elements, e.g. V0.4S)
     # The zero registers and SP should not be in this list.
-    re_reg=re.compile(r"\$?\b([bhsdvq][12]?[0-9](\.\d\d?[bhsdvq])?|[bhsdvq]3[01](\.\d\d?[bhsdvq])?|[xw][12]?[0-9]|[xw]30)\b"),
+    re_reg=re.compile(r"\$?\b([bhsdvq]([12]?[0-9]|3[01])(\.\d\d?[bhsdvq])?|[xw][12]?[0-9]|[xw]30)\b"),
     re_sprel=re.compile(r"sp, #-?(0x[0-9a-fA-F]+|[0-9]+)\b"),
     re_large_imm=re.compile(r"-?[1-9][0-9]{2,}|-?0x[0-9a-f]{3,}"),
     re_imm=re.compile(r"(?<!sp, )#-?(0x[0-9a-fA-F]+|[0-9]+)\b"),


### PR DESCRIPTION
FP registers may be followed by data width and number of elements,
e.g. V0.4S (instead of just V0). For simplicity, we don't actually
check if the combination of data width / number of elements makes sense
or list all the combinations in the regex -- instead, the regex simply
looks for one or two digits followed by a valid letter.

Before:

![before](https://user-images.githubusercontent.com/4209061/149641010-cbe3a709-026a-4b1b-b2fd-25cd140509aa.png)

After:

![after](https://user-images.githubusercontent.com/4209061/149641026-b49bc5c5-184a-489b-8006-1d55d8933144.png)
