### PR TITLE
Allow diffing specific object files

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -110,6 +110,15 @@ if __name__ == "__main__":
         see symbol names. (Recommended)""",
     )
     parser.add_argument(
+        "-f",
+        "--objfile",
+        dest="objfile",
+        type=str,
+        help="""File path for an object file being diffed. When used
+        the map file isn't searched for the function given. Useful for dynamically
+        linked libraries."""
+    )
+    parser.add_argument(
         "-e",
         "--elf",
         dest="diff_elf_symbol",
@@ -388,6 +397,7 @@ class Config:
 
     # Build/objdump options
     diff_obj: bool
+    objfile: str
     make: bool
     source_old_binutils: bool
     diff_section: str
@@ -472,6 +482,7 @@ def create_config(args: argparse.Namespace, project: ProjectSettings) -> Config:
         arch=arch,
         # Build/objdump options
         diff_obj=args.diff_obj,
+        objfile=args.objfile,
         make=args.make,
         source_old_binutils=args.source_old_binutils,
         diff_section=args.diff_section,
@@ -1301,7 +1312,10 @@ def dump_objfile(
     if start.startswith("0"):
         fail("numerical start address not supported with -o; pass a function name")
 
-    objfile, _ = search_map_file(start, project, config)
+    objfile = config.objfile
+    if not objfile:
+        objfile, _ = search_map_file(start, project, config)
+    
     if not objfile:
         fail("Not able to find .o file for function.")
 


### PR DESCRIPTION
When all the functions in a project aren't in a single map file it can be useful to define the object file used when using -o instead of doing something like searching every map file in the project. This pull requests implements an extra argument to diff.py that allows the user to give the path of an object file to be diffed.