### PR TITLE
ppc updates

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1112,7 +1112,7 @@ def search_map_file(
         find = re.findall(
             re.compile(
                 #            ram   elf rom
-                r"  \S+ \S+ (\S+) (\S+)  . "
+                r"  \S+ \S+ (\S+) (\S+) +\S+ "
                 + re.escape(fn_name)
                 + r"(?: \(entry of "
                 + re.escape(config.diff_section)

--- a/diff.py
+++ b/diff.py
@@ -204,8 +204,8 @@ if __name__ == "__main__":
         "--stop-jr-ra",
         dest="stop_jrra",
         action="store_true",
-        help="""Stop disassembling at the first 'jr ra'. Some functions have
-        multiple return points, so use with care!""",
+        help="""Stop disassembling at the first 'jr ra' (mips) or 'blr' (ppc).
+        Some functions have multiple return points, so use with care!""",
     )
     parser.add_argument(
         "-i",

--- a/diff.py
+++ b/diff.py
@@ -201,10 +201,10 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-s",
-        "--stop-jr-ra",
-        dest="stop_jrra",
+        "--stop-at-ret",
+        dest="stop_at_ret",
         action="store_true",
-        help="""Stop disassembling at the first 'jr ra' (mips) or 'blr' (ppc).
+        help="""Stop disassembling at the first return instruction.
         Some functions have multiple return points, so use with care!""",
     )
     parser.add_argument(
@@ -415,7 +415,7 @@ class Config:
     show_branches: bool
     show_line_numbers: bool
     show_source: bool
-    stop_jrra: bool
+    stop_at_ret: bool
     ignore_large_imms: bool
     ignore_addr_diffs: bool
     algorithm: str
@@ -502,7 +502,7 @@ def create_config(args: argparse.Namespace, project: ProjectSettings) -> Config:
         show_branches=args.show_branches,
         show_line_numbers=show_line_numbers,
         show_source=args.show_source or args.source_old_binutils,
-        stop_jrra=args.stop_jrra,
+        stop_at_ret=args.stop_at_ret,
         ignore_large_imms=args.ignore_large_imms,
         ignore_addr_diffs=args.ignore_addr_diffs,
         algorithm=args.algorithm,
@@ -1111,7 +1111,7 @@ def search_map_file(
     elif project.map_format == "mw":
         find = re.findall(
             re.compile(
-                #            ram   elf rom
+                #            ram   elf rom  alignment
                 r"  \S+ \S+ (\S+) (\S+) +\S+ "
                 + re.escape(fn_name)
                 + r"(?: \(entry of "
@@ -1813,7 +1813,7 @@ PPC_SETTINGS = ArchSettings(
         r"(\b|-)([0-9]+|0x[0-9a-fA-F]+)\b(?!\(r1)|[^ \t,]+@(l|ha|h|sda21)"
     ),
     re_reloc=re.compile(r"R_PPC_"),
-    arch_flags=["-m", "powerpc", "-M", "gekko"],
+    arch_flags=["-m", "powerpc", "-M", "broadway"],
     branch_instructions=PPC_BRANCH_INSTRUCTIONS,
     instructions_with_address_immediates=PPC_BRANCH_INSTRUCTIONS.union({"bl"}),
     proc=AsmProcessorPPC,
@@ -2082,7 +2082,7 @@ def process(dump: str, config: Config) -> List[Line]:
         num_instr += 1
         source_lines = []
 
-        if config.stop_jrra:
+        if config.stop_at_ret:
             if config.arch.name == "mips":
                 if mnemonic == "jr" and args == "ra":
                     stop_after_delay_slot = True

--- a/diff.py
+++ b/diff.py
@@ -2081,10 +2081,15 @@ def process(dump: str, config: Config) -> List[Line]:
         num_instr += 1
         source_lines = []
 
-        if config.stop_jrra and mnemonic == "jr" and args == "ra":
-            stop_after_delay_slot = True
-        elif stop_after_delay_slot:
-            break
+        if config.stop_jrra:
+            if config.arch.name == "mips":
+                if mnemonic == "jr" and args == "ra":
+                    stop_after_delay_slot = True
+                elif stop_after_delay_slot:
+                    break
+            if config.arch.name == "ppc":
+                if mnemonic == "blr":
+                    break
 
     processor.post_process(output)
     return output

--- a/diff.py
+++ b/diff.py
@@ -1813,6 +1813,7 @@ PPC_SETTINGS = ArchSettings(
         r"(\b|-)([0-9]+|0x[0-9a-fA-F]+)\b(?!\(r1)|[^ \t,]+@(l|ha|h|sda21)"
     ),
     re_reloc=re.compile(r"R_PPC_"),
+    arch_flags=["-m", "powerpc", "-M", "gekko"],
     branch_instructions=PPC_BRANCH_INSTRUCTIONS,
     instructions_with_address_immediates=PPC_BRANCH_INSTRUCTIONS.union({"bl"}),
     proc=AsmProcessorPPC,


### PR DESCRIPTION
- Made `--stop-jr-ra` work in ppc for the `blr` instruction
- Allowed multi-digit alignments in the mw symbol map regex
- Added arch_flags for ppc
    - `-m powerpc` fixes objdump saying "can't disassemble for architecture UNKNOWN!" when using on a biniary
    - `-M gekko` fixes disassembly of paired single instructions