### PR TITLE
Add arrow support to `j`s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .mypy_cache/
 __pycache__/
-.vscode
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .mypy_cache/
 __pycache__/
+.vscode

--- a/diff.py
+++ b/diff.py
@@ -1739,6 +1739,7 @@ class ArchSettings:
     re_reloc: Pattern[str]
     branch_instructions: Set[str]
     instructions_with_address_immediates: Set[str]
+    jump_instructions: Set[str] = field(default_factory=set)
     forbidden: Set[str] = field(default_factory=lambda: set(string.ascii_letters + "_"))
     arch_flags: List[str] = field(default_factory=list)
     branch_likely_instructions: Set[str] = field(default_factory=set)
@@ -1773,6 +1774,18 @@ MIPS_BRANCH_INSTRUCTIONS = MIPS_BRANCH_LIKELY_INSTRUCTIONS.union(
         "bc1t",
         "bc1f",
     }
+)
+
+MIPS_JUMP_ADDR_INSTRUCTIONS = {
+    "jal",
+    "j",
+}
+MIPS_JUMP_REG_INSTRUCTIONS = {
+    "jalr",
+    "jr",
+}
+MIPS_JUMP_INSTRUCTIONS = set.union(
+    MIPS_JUMP_ADDR_INSTRUCTIONS, MIPS_JUMP_REG_INSTRUCTIONS
 )
 
 ARM32_PREFIXES = {"b", "bl"}
@@ -1938,8 +1951,11 @@ MIPS_SETTINGS = ArchSettings(
     arch_flags=["-m", "mips:4300"],
     branch_likely_instructions=MIPS_BRANCH_LIKELY_INSTRUCTIONS,
     branch_instructions=MIPS_BRANCH_INSTRUCTIONS,
-    instructions_with_address_immediates=MIPS_BRANCH_INSTRUCTIONS.union({"jal", "j"}),
-    delay_slot_instructions=MIPS_BRANCH_INSTRUCTIONS.union({"j", "jal", "jr", "jalr"}),
+    jump_instructions=MIPS_JUMP_INSTRUCTIONS,
+    instructions_with_address_immediates=set.union(
+        MIPS_BRANCH_INSTRUCTIONS, MIPS_JUMP_ADDR_INSTRUCTIONS
+    ),
+    delay_slot_instructions=set.union(MIPS_BRANCH_INSTRUCTIONS, MIPS_JUMP_INSTRUCTIONS),
     proc=AsmProcessorMIPS,
 )
 

--- a/diff.py
+++ b/diff.py
@@ -2705,9 +2705,6 @@ def do_diff(lines1: List[Line], lines2: List[Line], config: Config) -> Diff:
                             retargetted += f"+{line2_target[1]}"
                         line2.normalized_original = norm2 + retargetted
                         sc_base, _ = split_off_address(line2.scorable_line)
-                        # if mnemonic == "j":
-                        #     line2.scorable_line = sc_base + ".text+0x" + retargetted
-                        # else:
                         line2.scorable_line = sc_base + retargetted
                     same_target = line2_target == (line1.branch_target, 0)
                 else:

--- a/diff.py
+++ b/diff.py
@@ -1945,6 +1945,8 @@ MIPS_SETTINGS = ArchSettings(
 
 MIPSEL_SETTINGS = replace(MIPS_SETTINGS, name="mipsel", big_endian=False)
 
+MIPS_ARCH_NAMES = {"mips", "mipsel"}
+
 ARM32_SETTINGS = ArchSettings(
     name="arm32",
     re_int=re.compile(r"[0-9]+"),
@@ -2255,7 +2257,7 @@ def process(dump: str, config: Config) -> List[Line]:
 
         is_text_relative_j = False
         if (
-            arch.name == "mips"
+            arch.name in MIPS_ARCH_NAMES
             and mnemonic == "j"
             and symbol is not None
             and symbol.startswith(".text")
@@ -2363,7 +2365,7 @@ def field_matches_any_symbol(field: str, arch: ArchSettings) -> bool:
 
         return re.fullmatch((r"^@\d+$"), field) is not None
 
-    if arch.name in ("mips", "mipsel"):
+    if arch.name in MIPS_ARCH_NAMES:
         return "." in field
 
     # Example: ".text+0x34"


### PR DESCRIPTION
Thanks to @simonlindholm for walking me through this. (I just wish it still showed the `.text+0x`s 😔 )

Added .vscode to the gitignore, since it added settings.json with
```json
{
    "python.linting.mypyEnabled": true,
    "python.linting.enabled": true,
    "python.formatting.provider": "black"
}
```
which I imagine we don't want?