### PR TITLE
One-way and zero-way diffing, and expected_directory config option

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -3100,13 +3100,11 @@ def align_diffs(old_diff: Diff, new_diff: Diff, config: Config) -> TableData:
         diff_lines = compress_matching(diff_lines, config.compress.context)
 
     def diff_line_to_table_line(line: Tuple[OutputLine, ...]) -> TableLine:
-        cells: List[Tuple[Text, Optional["Line"]]] = []
-        for i in range(0, len(line)):
-            if i == 0:
-                base: Text = line[i].base or Text()
-                cells.append((base, line[i].line1))
-            else:
-                cells.append((line[i].fmt2, line[i].line2))
+        cells: List[Tuple[Text, Optional["Line"]]] = [
+            (line[0].base or Text(), line[0].line1)
+        ]
+        for i in range(1, len(line)):
+            cells.append((line[i].fmt2, line[i].line2))
 
         return TableLine(
             key=line[0].key2,

--- a/diff.py
+++ b/diff.py
@@ -3100,11 +3100,11 @@ def align_diffs(old_diff: Diff, new_diff: Diff, config: Config) -> TableData:
         diff_lines = compress_matching(diff_lines, config.compress.context)
 
     def diff_line_to_table_line(line: Tuple[OutputLine, ...]) -> TableLine:
-        cells: List[Tuple[Text, Optional["Line"]]] = [
+        cells = [
             (line[0].base or Text(), line[0].line1)
         ]
-        for i in range(1, len(line)):
-            cells.append((line[i].fmt2, line[i].line2))
+        for ol in line[1:]:
+            cells.append((ol.fmt2, ol.line2))
 
         return TableLine(
             key=line[0].key2,

--- a/diff.py
+++ b/diff.py
@@ -1446,7 +1446,7 @@ def dump_objfile(
         fail(f"Not able to find .o file for function: {objfile} is not a file.")
 
     refobjfile = os.path.join(project.expected_directory, objfile)
-    if not os.path.isfile(refobjfile):
+    if config.diff_mode != DiffMode.SINGLE and not os.path.isfile(refobjfile):
         fail(f'Please ensure an OK .o file exists at "{refobjfile}".')
 
     if project.disassemble_all:
@@ -3400,8 +3400,10 @@ def main() -> None:
     if args.base_asm is not None:
         with open(args.base_asm) as f:
             basedump = f.read()
-    else:
+    elif config.diff_mode != DiffMode.SINGLE:
         basedump = run_objdump(basecmd, config, project)
+    else:
+        basedump = ""
 
     mydump = run_objdump(mycmd, config, project)
 

--- a/diff_settings.py
+++ b/diff_settings.py
@@ -7,5 +7,6 @@ def apply(config, args):
     # config["arch"] = "mips"
     # config["map_format"] = "gnu" # gnu, mw, ms
     # config["build_dir"] = "build/" # only needed for mw and ms map format
+    # config["expected_dir"] = "expected/" # needed for -o
     # config["makeflags"] = []
     # config["objdump_executable"] = ""


### PR DESCRIPTION
I've added two new cli args in this PR: `-0` and `-1` for just viewing (not diffing) asm by itself. The 0 mode views base and 1 views current.

This is currently done by just telling asm-differ to diff one side against itself and then only display one of the two identical sides. I thought this would be the best way to go about doing this, as it allows us to run through all existing diff code (which probably tidies things up as well) and not have to touch too many different parts of the codebase in doing so, but I'm happy to try going a different direction if people have suggestions.

I also added a config option to specifiy the expected directory, as Paper Mario has a non-standard directory structure which previously required dumb manual modifications to diff.py - no longer! (fixes #49)