### PR TITLE
Package for use as a library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .mypy_cache/
 __pycache__/
+poetry.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "asm-differ"
+version = "0.1.0"
+description = ""
+authors = ["Simon Lindholm <simon.lindholm10@gmail.com>"]
+license = "UNLICENSE"
+readme = "README.md"
+packages = [{ include = "diff.py" }]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+colorama = "^0.4.6"
+ansiwrap = "^0.8.4"
+watchdog = "^2.2.0"
+python-Levenshtein = "^0.20.8"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Adds a `pyproject.toml` so that [other projects](https://github.com/decompme/decomp.me/pull/624) can add asm-differ as a git dependency.
