### PR TITLE
Basic SH2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # asm-differ
 
-Nice differ for assembly code. Currently supports MIPS, PPC, AArch64, and ARM32; should be easy to hack to support other instruction sets.
+Nice differ for assembly code. Currently supports MIPS, PPC, AArch64, ARM32, and SH2; should be easy to hack to support other instruction sets.
 
 ![](screenshot.png)
 

--- a/diff.py
+++ b/diff.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         argcomplete = None
 
     parser = argparse.ArgumentParser(
-        description="Diff MIPS, PPC, AArch64, or ARM32 assembly."
+        description="Diff MIPS, PPC, AArch64, ARM32, or SH2 assembly."
     )
 
     start_argument = parser.add_argument(

--- a/diff.py
+++ b/diff.py
@@ -2023,7 +2023,7 @@ SH2_BRANCH_INSTRUCTIONS = {
     "bt",
     "bt.s",
     "bra",
-    "bsr"
+    "bsr",
 }
 
 MIPS_SETTINGS = ArchSettings(
@@ -2179,7 +2179,7 @@ ARCH_SETTINGS = [
     AARCH64_SETTINGS,
     PPC_SETTINGS,
     I686_SETTINGS,
-    SH2_SETTINGS
+    SH2_SETTINGS,
 ]
 
 


### PR DESCRIPTION
This PR adds basic support for the Hitachi SH2 architecture. I'm not sure about relocations, re_sprel, or re_large_imm. The binary I'm testing on seems to work ok without relocations. The SH2 doesn't have stack pointer relative instructions and the largest immediate size is a 12-bit displacement for BRA and BSR. Otherwise it's 8 bit. Instruction list is on PDF page 44 here: https://antime.kapsi.fi/sega/files/h12p0.pdf

Highlighting and branches seem to be OK by my testing:

<img width="657" alt="image" src="https://user-images.githubusercontent.com/122322823/230424655-dca3739f-f9d8-48c7-965b-46b8d1760774.png">