### PR TITLE
Expand --stop-at-ret to stop at variable return count

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -213,9 +213,8 @@ if __name__ == "__main__":
         "--stop-at-ret",
         dest="stop_at_ret",
         action="count",
-        help="""Stop disassembling when a return instruction is encountered.
-        As some functions have multiple return points, you can pass this
-        multiple times.""",
+        help="""Stop disassembling at the first return instruction.
+        You can also pass -ss to stop at the second return instruction, and so on.""",
     )
     parser.add_argument(
         "-i",

--- a/diff.py
+++ b/diff.py
@@ -212,14 +212,10 @@ if __name__ == "__main__":
         "-s",
         "--stop-at-ret",
         dest="stop_at_ret",
-        metavar="N",
-        type=int,
-        default=None,
-        const=1,
-        nargs='?',
-        help="""Stop disassembling at the Nth return instruction.
-        Defaults to not stopping on returns, or stopping at the first return
-        encountered if N is not specified.""",
+        action="count",
+        help="""Stop disassembling when a return instruction is encountered.
+        As some functions have multiple return points, you can pass this
+        multiple times.""",
     )
     parser.add_argument(
         "-i",

--- a/diff.py
+++ b/diff.py
@@ -450,7 +450,7 @@ class Config:
     show_branches: bool
     show_line_numbers: bool
     show_source: bool
-    stop_at_ret: int
+    stop_at_ret: Optional[int]
     ignore_large_imms: bool
     ignore_addr_diffs: bool
     algorithm: str
@@ -2587,7 +2587,7 @@ def process(dump: str, config: Config) -> List[Line]:
         num_instr += 1
         source_lines = []
 
-        if config.stop_at_ret and processor.is_end_of_function(mnemonic, args):
+        if rets_remaining and processor.is_end_of_function(mnemonic, args):
             rets_remaining -= 1
             if rets_remaining == 0:
                 break

--- a/test.py
+++ b/test.py
@@ -24,13 +24,13 @@ class TestSh2(unittest.TestCase):
             compress=None, 
             show_rodata_refs=True, 
             show_branches=True,
-            show_line_numbers=False, 
-            show_source=False, 
-            stop_at_ret=None, 
-            ignore_large_imms=False, 
-            ignore_addr_diffs=True, 
-            algorithm='levenshtein', 
-            reg_categories={}, 
+            show_line_numbers=False,
+            show_source=False,
+            stop_at_ret=None,
+            ignore_large_imms=False,
+            ignore_addr_diffs=True,
+            algorithm="levenshtein",
+            reg_categories={},
         )
         return config
 

--- a/test.py
+++ b/test.py
@@ -25,7 +25,7 @@ class TestSh2(unittest.TestCase):
             show_branches=True,
             show_line_numbers=False, 
             show_source=False, 
-            stop_at_ret=False, 
+            stop_at_ret=None, 
             ignore_large_imms=False, 
             ignore_addr_diffs=True, 
             algorithm='levenshtein', 


### PR DESCRIPTION
When diffing two very different functions in binary mode, the `-s` command-line switch is essential in order to give the diff algorithm a chance to output something useful. If it is not used, the diff algorithm cannot effectively match up the source and target instructions and outputs garbage.

The `-s` switch causes the diff to stop at the first return instruction it finds. This is useful for producing more relevant diffs, but comes at the cost of truncating output when there are several return instructions in the same function. That truncation removes essential context for the user viewing the diff.

This patch modifies the `--stop-at-ret`/`-s` command-line flag to optionally take N, an integer argument, and truncate the diff at the Nth return instruction found. The existing behaviour of the flags is retained by defaulting N to one when there is no integer argument passed along with the flag.

The benefits of this flag are outlined below with an example function (a deliberately different `DerefSym` from AMS 3.10, for those curious)

Here is an example of a poorly-matched function with `-s` not used:
![image](https://github.com/simonlindholm/asm-differ/assets/59924908/41cf68fe-fb99-44dd-ac91-3ddb2aa16711)
Note how the diff algorithm only detects a partial instruction match __two__ functions later in the binary than the target function, making that match and all subsequent matches useless from a comparison point of view.

Here is an example of the same function, but using `-s` this time:
![image](https://github.com/simonlindholm/asm-differ/assets/59924908/b42b64bb-9da5-46ca-8ab6-9a9de778a233)
The diff has a little bit more context, but now we have a conditional branch on line two with a target outside of the listing. That won't do in most cases of function decompilation.

Lastly, here is the same function with the correct amount of returns passed (`-s 2`):
![image](https://github.com/simonlindholm/asm-differ/assets/59924908/fe325d62-6b7a-4a3e-85ab-613aedde91ab)
The functions are still extremely different, but asm-differ now gives a high-quality look at how they are different.