### PR TITLE
Fix indirect calls like calll *0x123456

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -2571,7 +2571,7 @@ def process(dump: str, config: Config) -> List[Line]:
         if (
             mnemonic in arch.branch_instructions or is_text_relative_j
         ) and symbol is None:
-            x86_longjmp = re.search(r"\*(.*)\(", args)
+            x86_longjmp = re.search(r"\*([0-9a-fA-Fx]+)", args)
             if x86_longjmp:
                 capture = x86_longjmp.group(1)
                 if capture != "":


### PR DESCRIPTION
This would fail on `calll *0x123456` instructions with an exception claiming it failed to parse `*0x123456` as an int because of the prefixed star.

I'm not sure if this fix is correct - I have absolutely no clue what much of the code in here is trying to do. But it does allow the differ to continue.