### PR TITLE
Revert incorrect logic of previous commit "Remove ".text+" from PowerPC ProDG-generated assembly"

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -2548,10 +2548,8 @@ def process(dump: str, config: Config) -> List[Line]:
 
         is_text_relative_j = False
         if (
-            (
-                (arch.name in MIPS_ARCH_NAMES and mnemonic == "j")
-                or (arch.name == "ppc" and mnemonic in PPC_BRANCH_INSTRUCTIONS)
-            )
+            arch.name in MIPS_ARCH_NAMES
+            and mnemonic == "j"
             and symbol is not None
             and symbol.startswith(".text")
         ):


### PR DESCRIPTION
This caused an issue with relocations being processed as an immediate to be added to the branch instruction offset.