### PR TITLE
Ignore hex/decimal differences in 'li' on MIPS

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1577,9 +1577,9 @@ class AsmProcessorMIPS(AsmProcessor):
 
     def _normalize_arch_specific(self, mnemonic: str, row: str) -> str:
         if mnemonic == "li":
-            # only consider values of 0-9 equivalent
-            regex = re.compile(f"(0x[0-9])")
-            return re.sub(regex, lambda m: str(int(m.group(1), 16)), row)
+            # only consider values of 1-9 equivalent
+            regex = re.compile(f",(0x[1-9])$")
+            return re.sub(regex, lambda m: f",{int(m.group(1), 16)}", row)
         return row
 
     def process_reloc(self, row: str, prev: str) -> Tuple[str, Optional[str]]:

--- a/diff.py
+++ b/diff.py
@@ -470,6 +470,7 @@ class Config:
     penalty_reordering = 60
     penalty_insertion = 100
     penalty_deletion = 100
+    ignore_equivalent_immediates = False
 
 
 def create_project_settings(settings: Dict[str, Any]) -> ProjectSettings:
@@ -1576,9 +1577,8 @@ class AsmProcessorMIPS(AsmProcessor):
         self.seen_jr_ra = False
 
     def _normalize_arch_specific(self, mnemonic: str, row: str) -> str:
-        if mnemonic == "li":
-            # only consider values of 1-9 equivalent
-            regex = re.compile(f",(0x[1-9])$")
+        if self.config.ignore_equivalent_immediates and mnemonic == "li":
+            regex = re.compile(f",(0x[1-9])$")  # only 1 thru 9
             return re.sub(regex, lambda m: f",{int(m.group(1), 16)}", row)
         return row
 
@@ -2185,7 +2185,9 @@ MIPS_SETTINGS = ArchSettings(
     proc=AsmProcessorMIPS,
 )
 
-MIPSEL_SETTINGS = replace(MIPS_SETTINGS, name="mipsel", big_endian=False)
+MIPSEL_SETTINGS = replace(
+    MIPS_SETTINGS, name="mipsel", big_endian=False, arch_flags=["-m", "mips:3000"]
+)
 
 MIPSEE_SETTINGS = replace(
     MIPSEL_SETTINGS, name="mipsee", arch_flags=["-m", "mips:5900"]

--- a/diff.py
+++ b/diff.py
@@ -1575,11 +1575,13 @@ class AsmProcessorMIPS(AsmProcessor):
     def __init__(self, config: Config) -> None:
         super().__init__(config)
         self.seen_jr_ra = False
+        self.ignore_equivalent_immediates_regex = re.compile(r",0x([1-9])$")
 
     def _normalize_arch_specific(self, mnemonic: str, row: str) -> str:
         if self.config.ignore_equivalent_immediates and mnemonic == "li":
-            regex = re.compile(f",0x([1-9])$")  # only 1 thru 9
-            return re.sub(regex, lambda m: f",{m.group(1)}", row)
+            return re.sub(
+                self.ignore_equivalent_immediates_regex, lambda m: f",{m.group(1)}", row
+            )
         return row
 
     def process_reloc(self, row: str, prev: str) -> Tuple[str, Optional[str]]:

--- a/diff.py
+++ b/diff.py
@@ -1578,8 +1578,8 @@ class AsmProcessorMIPS(AsmProcessor):
 
     def _normalize_arch_specific(self, mnemonic: str, row: str) -> str:
         if self.config.ignore_equivalent_immediates and mnemonic == "li":
-            regex = re.compile(f",(0x[1-9])$")  # only 1 thru 9
-            return re.sub(regex, lambda m: f",{int(m.group(1), 16)}", row)
+            regex = re.compile(f",0x([1-9])$")  # only 1 thru 9
+            return re.sub(regex, lambda m: f",{m.group(1)}", row)
         return row
 
     def process_reloc(self, row: str, prev: str) -> Tuple[str, Optional[str]]:

--- a/diff.py
+++ b/diff.py
@@ -1577,9 +1577,9 @@ class AsmProcessorMIPS(AsmProcessor):
 
     def _normalize_arch_specific(self, mnemonic: str, row: str) -> str:
         if mnemonic == "li":
-            return re.sub(
-                f"(-?0x[0-9a-fA-F]+)", lambda m: str(int(m.group(1), 16)), row
-            )
+            # only consider values of 0-9 equivalent
+            regex = re.compile(f"(0x[0-9])")
+            return re.sub(regex, lambda m: str(int(m.group(1), 16)), row)
         return row
 
     def process_reloc(self, row: str, prev: str) -> Tuple[str, Optional[str]]:

--- a/diff.py
+++ b/diff.py
@@ -470,7 +470,7 @@ class Config:
     penalty_reordering = 60
     penalty_insertion = 100
     penalty_deletion = 100
-    ignore_equivalent_immediates = False
+    ignore_equivalent_immediates: bool = False
 
 
 def create_project_settings(settings: Dict[str, Any]) -> ProjectSettings:
@@ -557,6 +557,7 @@ def create_config(args: argparse.Namespace, project: ProjectSettings) -> Config:
         ignore_addr_diffs=args.ignore_addr_diffs,
         algorithm=args.algorithm,
         reg_categories=project.reg_categories,
+        ignore_equivalent_immediates=args.ignore_equivalent_immediates,
     )
 
 
@@ -1665,7 +1666,7 @@ class AsmProcessorPPC(AsmProcessor):
             # Replace the current offset with the next line's ".text+0x" offset
             splitArgs = args.split(",")
             splitArgs[-1] = next_row.split(".text+0x")[-1]
-            args = ','.join(splitArgs)
+            args = ",".join(splitArgs)
 
         return mnemonic, args
 

--- a/diff.py
+++ b/diff.py
@@ -1575,6 +1575,13 @@ class AsmProcessorMIPS(AsmProcessor):
         super().__init__(config)
         self.seen_jr_ra = False
 
+    def _normalize_arch_specific(self, mnemonic: str, row: str) -> str:
+        if mnemonic == "li":
+            return re.sub(
+                f"(-?0x[0-9a-fA-F]+)", lambda m: str(int(m.group(1), 16)), row
+            )
+        return row
+
     def process_reloc(self, row: str, prev: str) -> Tuple[str, Optional[str]]:
         arch = self.config.arch
         if "R_MIPS_NONE" in row or "R_MIPS_JALR" in row:


### PR DESCRIPTION
Is this the best way to tackle this? I put it behind a guard so we aren't trying to do a regex match for every line...

With this change:
![image](https://github.com/simonlindholm/asm-differ/assets/22226349/c5109dc1-d240-4e48-878f-8a78b7dbb28b)
Without:
![image](https://github.com/simonlindholm/asm-differ/assets/22226349/fa449ec9-2c12-4608-bfef-5f6cd1054deb)


**[edit]** Just seen the issue here https://github.com/simonlindholm/asm-differ/issues/121, which is pretty much what this PR is trying to address - outside of pseudo operations, its just trying to ignore 0x6 vs 6...