### PR TITLE
Adjust mw map regex to support older versions

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1263,8 +1263,8 @@ def search_map_file(
             return cands[0]
     elif project.map_format == "mw":
         find = re.findall(
-            #            ram   elf rom  alignment
-            r"  \S+ \S+ (\S+) (\S+) +\S+ "
+            # start address, size, virtual address, file offset, alignment
+            r"  \S+ \S+ (\S+) (\S+)? +(?:\S+ )?"
             + re.escape(fn_name)
             + r"(?: \(entry of "
             + re.escape(config.diff_section)
@@ -1276,7 +1276,10 @@ def search_map_file(
         if len(find) > 1:
             fail(f"Found multiple occurrences of function {fn_name} in map file.")
         if len(find) == 1:
-            rom = int(find[0][1], 16)
+            if find[0][1]:
+                rom = int(find[0][1], 16)
+            else:
+                rom = None
             objname = find[0][2]
             objfile = search_build_objects(objname, project)
 

--- a/diff.py
+++ b/diff.py
@@ -1264,7 +1264,7 @@ def search_map_file(
     elif project.map_format == "mw":
         find = re.findall(
             # start address, size, virtual address, file offset, alignment
-            r"  \S+ \S+ (\S+) (\S+)? +(?:\S+ )?"
+            r"  [0-9a-f]{8} [0-9a-f]{6} ([0-9a-f]{8})(?: ([0-9a-f]{8}))?(?: +\S{1,2})? +"
             + re.escape(fn_name)
             + r"(?: \(entry of "
             + re.escape(config.diff_section)


### PR DESCRIPTION
For codewarrior 1.1 (compiler version 2.3.3 build 137) the map format looks like this:

```
  Starting        Virtual
  address  Size   address
  -----------------------
  00000000 000864 800055a0  1 .text     xlCoreGCN.o
  00000000 000000 800055a0 xlCoreBeforeRender (entry of .text)  xlCoreGCN.o
  0000006c 000000 8000560c lbl_8000560C (entry of .text)        xlCoreGCN.o
  000000b0 000000 80005650 lbl_80005650 (entry of .text)        xlCoreGCN.o
  000000d4 000000 80005674 main (entry of .text)        xlCoreGCN.o
```

It's missing the "file offset" column compared to codewarrior 2.7:
```
  Starting        Virtual  File
  address  Size   address  offset
  ---------------------------------
  00000000 005afc 80007020 00003200  1 .text    code_80007020.o
  00000000 000000 80007020 00003200    func_80007020 (entry of .text)   code_80007020.o
  00000090 000000 800070b0 00003290    lbl_800070B0 (entry of .text)    code_80007020.o
  000000a4 000000 800070c4 000032a4    func_800070C4 (entry of .text)   code_80007020.o
  000000ac 000000 800070cc 000032ac    func_800070CC (entry of .text)   code_80007020.o
```

So I changed the regex to allow for the missing file offset. I also made the alignment field optional so that things like `xlCoreBeforeRender` above can still be diffed.

I tested this on both the zeldaret/oot-vc (codewarrior 2.7) and zeldaret/oot-gc (codewarrior 1.1) but I'm not sure if there are more versions I should test.