### PR TITLE
Add `bal` to `MIPS_BRANCH_INSTRUCTIONS`

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -2037,6 +2037,7 @@ MIPS_BRANCH_INSTRUCTIONS = MIPS_BRANCH_LIKELY_INSTRUCTIONS.union(
         "bltz",
         "bc1t",
         "bc1f",
+        "bal",
     }
 )
 

--- a/diff.py
+++ b/diff.py
@@ -2037,7 +2037,6 @@ MIPS_BRANCH_INSTRUCTIONS = MIPS_BRANCH_LIKELY_INSTRUCTIONS.union(
         "bltz",
         "bc1t",
         "bc1f",
-        "bal",
     }
 )
 
@@ -2257,8 +2256,8 @@ MIPS_SETTINGS = ArchSettings(
     arch_flags=["-m", "mips:4300"],
     branch_likely_instructions=MIPS_BRANCH_LIKELY_INSTRUCTIONS,
     branch_instructions=MIPS_BRANCH_INSTRUCTIONS,
-    instructions_with_address_immediates=MIPS_BRANCH_INSTRUCTIONS.union({"j", "jal"}),
-    delay_slot_instructions=MIPS_BRANCH_INSTRUCTIONS.union({"j", "jal", "jr", "jalr"}),
+    instructions_with_address_immediates=MIPS_BRANCH_INSTRUCTIONS.union({"j", "jal", "bal"}),
+    delay_slot_instructions=MIPS_BRANCH_INSTRUCTIONS.union({"j", "jal", "jr", "jalr", "bal"}),
     proc=AsmProcessorMIPS,
 )
 


### PR DESCRIPTION
Without this is not possible to use diff.py on functions with `bal` instructions because it raises an exception while parsing objdump's output.

This is caused because `reloc_addend_from_imm` tries to convert the hex without prefix to int with `int(imm, 0)`.