### PR TITLE
i686: regex: Support using the FS segment register for immediates

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1885,6 +1885,10 @@ class AsmProcessorI686(AsmProcessor):
             offset = True
 
         if not addr_imm:
+            addr_imm = re.search(r"(^|(?<=\*)|(?<=\%fs\:))0x[0-9a-f]+", args)
+            offset = True
+            
+        if not addr_imm:
             assert False, f"failed to find address immediate for line '{prev}'"
 
         start, end = addr_imm.span()

--- a/diff.py
+++ b/diff.py
@@ -1885,9 +1885,9 @@ class AsmProcessorI686(AsmProcessor):
             offset = True
 
         if not addr_imm:
-            addr_imm = re.search(r"(^|(?<=\*)|(?<=\%fs\:))0x[0-9a-f]+", args)
+            addr_imm = re.search(r"(^|(?<=\*)|(?<=\%[fgdecs]s\:))0x[0-9a-f]+", args)
             offset = True
-            
+
         if not addr_imm:
             assert False, f"failed to find address immediate for line '{prev}'"
 


### PR DESCRIPTION
This should help fix part of #143.