### PR TITLE
License: add SPDX identifier and copyright

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # PYTHON_ARGCOMPLETE_OK
+
+# SPDX-FileCopyrightText: 2019-2024 asm-differ contributors
+# SPDX-License-Identifier: Unlicense
+
 import argparse
 import enum
 import sys

--- a/test.py
+++ b/test.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023-2024 asm-differ contributors
+# SPDX-License-Identifier: Unlicense
+
 import unittest
 import diff
 import json


### PR DESCRIPTION
SPDX is basically a standard (machine-readable) way to specify license/copyright info of files
https://spdx.dev/

Licenses list: https://spdx.org/licenses/

It really does nothing immediate for this project specifically, but I suggest this in the hope it can help others learning about / discovering SPDX.