### PR TITLE
Add function symbols to diff output

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1126,7 +1126,7 @@ def restrict_to_function(dump: str, fn_name: str) -> str:
     try:
         # Find the start of the line that contains "<fn_name>:"
         ind = dump.rfind("\n", 0, dump.index(f"<{fn_name}>:"))
-        return dump[ind:]
+        return dump[ind + 1 :]
     except ValueError:
         return ""
 

--- a/diff.py
+++ b/diff.py
@@ -1125,8 +1125,8 @@ def run_make_capture_output(
 def restrict_to_function(dump: str, fn_name: str) -> str:
     try:
         # Find the start of the line that contains "<fn_name>:"
-        ind = dump.rfind("\n", 0, dump.index(f"<{fn_name}>:"))
-        return dump[ind + 1 :]
+        ind = dump.rfind("\n", 0, dump.index(f"<{fn_name}>:")) + 1
+        return dump[ind:]
     except ValueError:
         return ""
 
@@ -2601,11 +2601,11 @@ def process(dump: str, config: Config) -> List[Line]:
                 
                 output.append(
                     Line(
-                        mnemonic=function_name, # this is needed for score changes
-                        diff_row=function_name, # this is needed to be set for highlighting
-                        original=function_name, # this is the value that is printed
+                        mnemonic="<label>",
+                        diff_row=function_name,
+                        original=function_name,
                         normalized_original=function_name,
-                        scorable_line=function_name,
+                        scorable_line="label " + function_name,
                     )
                 )
             continue

--- a/diff.py
+++ b/diff.py
@@ -2598,7 +2598,13 @@ def process(dump: str, config: Config) -> List[Line]:
         row = lines[i]
         i += 1
 
-        if config.diff_function_symbols:
+        if not row:
+            continue
+
+        if config.diff_function_symbols == True:
+            # If diffing function symbols is enabled
+            # Check if the line contains a function label
+            # If so, create a line to diff for the label
 
             # Regex the current row to check for "OFFSET <SYM>:"
             funcNameMatch = re.match(r"[0-9A-Fa-f]+ <(.+)>:", row)
@@ -2615,10 +2621,9 @@ def process(dump: str, config: Config) -> List[Line]:
                         scorable_line="...",
                     )
                 )
-
-        if not row:
-            continue
-
+                continue
+        
+        # Filter out function label lines "OFFSET <SYM>:"
         if re.match(r"^[0-9a-f]+ <.*>:$", row):
             continue
 

--- a/diff.py
+++ b/diff.py
@@ -2609,11 +2609,11 @@ def process(dump: str, config: Config) -> List[Line]:
                 funcSym = funcNameMatch.groups()[0] + ":"
                 output.append(
                     Line(
-                        mnemonic="...",
-                        diff_row=funcSym,
-                        original=funcSym,
+                        mnemonic=funcSym, # this is needed for score changes
+                        diff_row=funcSym, # this is needed to be set for highlighting
+                        original=funcSym, # this is the value that is printed
                         normalized_original="...",
-                        scorable_line=funcSym,
+                        scorable_line="...",
                     )
                 )
 

--- a/diff.py
+++ b/diff.py
@@ -1133,7 +1133,7 @@ def restrict_to_function(dump: str, fn_name: str) -> str:
         if restrictFindResults is None:
             # If the regex doesn't find anything, use the old restriction
             ind = dump.index("\n", dump.index(f"<{fn_name}>:"))
-            return dump[ind :]
+            return dump[ind + 1 :]
         else:
             # If it does, split the dump from the beginning of the line to the end of the dump
             # this is to ensure that later, we can find the format "OFFSET <SYM>:" in the first line

--- a/diff.py
+++ b/diff.py
@@ -2602,8 +2602,7 @@ def process(dump: str, config: Config) -> List[Line]:
 
             # Regex the current row to check for "OFFSET <SYM>:"
             funcNameMatch = re.match(r"[0-9A-Fa-f]+ <(.+)>:", row)
-
-            # if the list isn't empty, we have a match
+            
             if funcNameMatch:
                 # Add the function symbol to the diff output
                 funcSym = funcNameMatch.groups()[0] + ":"

--- a/test.py
+++ b/test.py
@@ -31,6 +31,7 @@ class TestSh2(unittest.TestCase):
             ignore_addr_diffs=True,
             algorithm="levenshtein",
             reg_categories={},
+            diff_function_symbols=False,
         )
         return config
 


### PR DESCRIPTION
This adds function symbols to the output while diffing. The function symbols will be highlighted when different and contribute to the score.
Added an option of "-d" or "--diff-function-symbols" to enable function symbols in the diff.

![Different Labels](https://github.com/simonlindholm/asm-differ/assets/57328807/2d8bd8aa-ffb5-46d2-acc7-40a7ccc2941f)
![Multiple Functions](https://github.com/simonlindholm/asm-differ/assets/57328807/95f666c6-f743-430a-aed7-abee767b80f0)
