### PR TITLE
Use comments to apply relocations to certain instructions

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1613,7 +1613,7 @@ class AsmProcessor:
         return objdump
 
     def pre_process(
-        self, mnemonic: str, args: str, next_row: Optional[str]
+        self, mnemonic: str, args: str, next_row: Optional[str], comment: str|None
     ) -> Tuple[str, str]:
         return mnemonic, args
 
@@ -1694,7 +1694,7 @@ class AsmProcessorMIPS(AsmProcessor):
 
 class AsmProcessorPPC(AsmProcessor):
     def pre_process(
-        self, mnemonic: str, args: str, next_row: Optional[str]
+        self, mnemonic: str, args: str, next_row: Optional[str], comment: str|None
     ) -> Tuple[str, str]:
         if next_row and "R_PPC_EMB_SDA21" in next_row:
             # With sda21 relocs, the linker transforms `r0` into `r2`/`r13`, and
@@ -1730,6 +1730,12 @@ class AsmProcessorPPC(AsmProcessor):
             splitArgs = args.split(",")
             splitArgs[-1] = next_row.split(".text+0x")[-1]
             args = ",".join(splitArgs)
+
+        if comment is not None and mnemonic == "bl":
+            # if the mnemonic is bl and the comment doesn't match
+            # <.text+0x...> replace the args with the contents of the comment
+            if re.search(r"<.+\+0x[0-9a-fA-F]+>", comment) == None:
+                args = comment[1:-1]
 
         return mnemonic, args
 
@@ -2111,7 +2117,7 @@ class AsmProcessorSH2(AsmProcessor):
 
 class AsmProcessorM68k(AsmProcessor):
     def pre_process(
-        self, mnemonic: str, args: str, next_row: Optional[str]
+        self, mnemonic: str, args: str, next_row: Optional[str], comment: str|None
     ) -> Tuple[str, str]:
         # replace objdump's syntax of pointer accesses with the equivilant in AT&T syntax for readability
         return mnemonic, re.sub(
@@ -2835,7 +2841,7 @@ def process(dump: str, config: Config) -> List[Line]:
         args = row_parts[1].strip() if len(row_parts) >= 2 else ""
 
         next_line = lines[i] if i < len(lines) else None
-        mnemonic, args = processor.pre_process(mnemonic, args, next_line)
+        mnemonic, args = processor.pre_process(mnemonic, args, next_line, comment)
         row = mnemonic + "\t" + args.replace("\t", "  ")
 
         addr = ""

--- a/diff.py
+++ b/diff.py
@@ -1733,7 +1733,10 @@ class AsmProcessorPPC(AsmProcessor):
 
         if (
             comment is not None
-            and (next_row is None or re.search(self.config.arch.re_reloc, next_row) is None)
+            and (
+                next_row is None
+                or re.search(self.config.arch.re_reloc, next_row) is None
+            )
             and mnemonic == "bl"
         ):
             # if the mnemonic is bl and the comment doesn't match

--- a/diff.py
+++ b/diff.py
@@ -1741,7 +1741,7 @@ class AsmProcessorPPC(AsmProcessor):
         ):
             # if the mnemonic is bl and the comment doesn't match
             # <.text+0x...> replace the args with the contents of the comment
-            if re.search(r"<.+\+0x[0-9a-fA-F]+>", comment) == None:
+            if re.search(r"<.+\+0x[0-9a-fA-F]+>", comment) is None:
                 args = comment[1:-1]
 
         return mnemonic, args

--- a/diff.py
+++ b/diff.py
@@ -1733,8 +1733,7 @@ class AsmProcessorPPC(AsmProcessor):
 
         if (
             comment is not None
-            and next_row is not None
-            and re.search(self.config.arch.re_reloc, next_row) is None
+            and (next_row is None or re.search(self.config.arch.re_reloc, next_row) is None)
             and mnemonic == "bl"
         ):
             # if the mnemonic is bl and the comment doesn't match


### PR DESCRIPTION
Addresses https://github.com/simonlindholm/asm-differ/issues/161

This is an attempt to fix an issue with the assembler not emitting relocations to static functions.

This may cause issues when absolute values are used such as in this scratch: https://decomp.me/scratch/KBprJ
The input assembly of the scratch is `bl 4` which objdump disassembles to ![image](https://github.com/simonlindholm/asm-differ/assets/57328807/52b3d7f3-a9ae-43d0-a147-93e6c642623d)

How asm-differ outputs this with my changes: 
![image](https://github.com/simonlindholm/asm-differ/assets/57328807/042d0b44-3706-47fc-b632-fb738d119e08)



Other instructions could be added but would cause issues such as conditional/unconditional branches to labels within functions
This scratch has labels which the assembler emits: https://decomp.me/scratch/hKpwa

objdump of the input assembly from the scratch: 
![image](https://github.com/simonlindholm/asm-differ/assets/57328807/fa16a86b-770f-4e86-9b60-7ea3742831dc)
These branch instructions have a comment which matches the comment regex that is used in AsmProcessorPPC.pre_process so the offsets (which we want) would get replaced with the label if these instructions are included.

This is why AsmProcessorPPC.pre_process checks for `bl`