### PR TITLE
Update MIPS field matches symbol regex

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -2996,7 +2996,7 @@ def field_matches_any_symbol(field: str, arch: ArchSettings) -> bool:
         return re.fullmatch((r"^@\d+$"), field) is not None
 
     if arch.name in MIPS_ARCH_NAMES:
-        if re.fullmatch(r"%(?:hi|lo)\((@\d+)\)", field):
+        if re.fullmatch(r"%(?:hi|lo|gp_rel)\((@\d+(?:\+0x[A-Fa-f0-9]+)?)\)", field):
             # Check for MWCC literal symbols that begin with "@"
             # "%hi(@20)" or "%lo(@20)"
             return True


### PR DESCRIPTION
This regex update will match missing cases from the previous regex including `%gp_rel(@num)`