### PR TITLE
Ignore FP 16-bit fixup

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -2051,8 +2051,27 @@ class AsmProcessorX86(AsmProcessor):
         return mnemonic, args
 
     def process_reloc(self, row: str, prev: str) -> Tuple[str, Optional[str]]:
-        if "WRTSEG" in row:  # ignore WRTSEG (watcom)
+        # ignore WRTSEG + FP 16-bit fixup
+        ignore = [
+            "WRTSEG",
+            "FIWRQQ",
+            "FIDRQQ",
+            "FIERQQ",
+            "FICRQQ",
+            "FISRQQ",
+            "FIARQQ",
+            "FIFRQQ",
+            "FIGRQQ",
+            "FJCRQQ",
+            "FJSRQQ",
+            "FJARQQ",
+            "FJFRQQ",
+            "FJGRQQ",
+        ]
+
+        if any(x in row for x in ignore):
             return prev, None
+
         repl = row.split()[-1]
         mnemonic, args = prev.split(maxsplit=1)
         offset = False


### PR DESCRIPTION
These fixups allow the linker or program loader to replace FP instructions by calls to an FP emulation library.

https://github.com/JWasm/JWasm/blob/master/fpfixup.c