### PR TITLE
SH improvements

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -2395,7 +2395,7 @@ class AsmProcessorSH2(AsmProcessor):
                 else:
                     mov_value = -1
 
-                    # Can be None if direct values are used but the pool 
+                    # Can be None if direct values are used but the pool
                     # doesn't get included in the asm
                     if mov_match.group(5) is not None:
                         mov_value = int(mov_match.group(5), 16)


### PR DESCRIPTION
This was supposed to be "a small contribution copying from ARM" but due to SH objects not having a way to signal objump what's data and what's code (like ARM does) it ended up exploding in size a bit, I'm not particularly good writing big chunks of code so I'm not sure how mergeable/readable/reviewable this is, I apologize in advance.

This is also my first real contribution to asm-differ so I'm sure there's stuff I missed or didn't get.

Among the changes:
- Added jump table detection, as generated by SHC and the scratch in #113 
- Added literal pool detection, literal pool moves get an inline comment like ARM does
- Related to this, literal pool mis-disassembly gets corrected to `.word`/`.long`
- Some relocation support, only the ones I noticed in some Dreamcast scratches, though SHC only seems to generate `R_SH_DIR32` relocs

While setting up the PR I noticed issue #113 which would be addressed by this, though this PR solves it by highly massaging what objdump puts out instead of the other idea of using a different disassembler's output.

Some before and afters:
<details>

| before | after |
 |--------|------|
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/58cbe7c6-4b8a-4ffa-b936-7579ce37e17b" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/bbe7d006-8610-436a-80ea-193f9347b21a" /> |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/f6969b76-9ea9-4b9b-b37e-fc99c9541b74" /> |  <img width="300" alt="image" src="https://github.com/user-attachments/assets/fd5cc44a-eb8b-4ea1-8986-5d84c70f07e6" /> |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/660eefb8-d822-4a42-aea6-a8cf97bdbdcb" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/8642e57d-2ad8-4406-94a4-9b0ef767e98a" /> |

</details>
