### PR TITLE
Make branch arrows appear only in their respective section

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -3290,10 +3290,11 @@ def process(dump: str, config: Config) -> List[Line]:
             tabs = row.split("\t")
             line_num = eval_line_num(line_num_str.strip())
 
-            if line_num is not None and line_num < prev_line_num:
-                line_group += 1
+            if line_num is not None:
+                if line_num < prev_line_num:
+                    line_group += 1
 
-            prev_line_num = line_num
+                prev_line_num = line_num
 
             # TODO: use --no-show-raw-insn for all arches
             if "--no-show-raw-insn" in arch.arch_flags:


### PR DESCRIPTION
This PR should fix #196, the logic is fairly simple and relies on the fact that the separate sections start at 0 to group `Line`s together

Before vs After (MIPS)
| Before | After |
|--------|--------|
| <img width="389" height="624" alt="image" src="https://github.com/user-attachments/assets/ff5dfd33-688e-4219-9701-533447e85f87" /> | <img width="389" height="624" alt="image" src="https://github.com/user-attachments/assets/f5ac6a65-2ecd-4dc8-aead-1c9d5f06a1c1" /> | 

 

