### PR TITLE
Fix xmm highlighting #203

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -3003,7 +3003,7 @@ X86_SETTINGS = ArchSettings(
     ),
     re_large_imm=re.compile(r"-?[1-9][0-9]{2,}|-?0x[0-9a-f]{3,}"),
     re_sprel=re.compile(r"-?(0x[0-9a-f]+|[0-9]+)(?=\((%ebp|%esi)\))"),
-    re_imm=re.compile(r"-?(0x[0-9a-f]+|[0-9]+)|([\?$_][^ \t,]+)"),
+    re_imm=re.compile(r"(?:\b|-)(0x[0-9a-f]+|[0-9]+)|([\?$_][^ \t,]+)"),
     re_reloc=re.compile(
         r"R_386_|dir32|DISP32|WRTSEG|OFF32|OFFPC32|OFF16|OFFPC16|SEG|FAR16"
     ),


### PR DESCRIPTION
Changes the immediate regex for x86 to fix how xmm{num} differences are highlighted.