### PR TITLE
Assorted SH fixes

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -3050,8 +3050,10 @@ I686_SETTINGS = replace(
 
 SH2_SETTINGS = ArchSettings(
     name="sh2",
-    # match -128-127 preceded by a '#' with a ',' after (8 bit immediates)
-    re_int=re.compile(r"(?<=#)(-?(?:1[01][0-9]|12[0-8]|[1-9][0-9]?|0))(?=,)"),
+    # match -128-127 or 0-255 preceded by a '#' with a ',' after (8 bit immediates)
+    re_int=re.compile(
+        r"(?<=#)(-?(?:12[0-7]|1[01][0-9]|[1-9][0-9]?|0)|(?:25[0-5]|2[0-4][0-9]|1[3-9][0-9]|12[8-9]))(?=,)"
+    ),
     # match <text>, match ! and after
     re_comment=re.compile(r"<.*?>|!.*"),
     #   - r0-r15 general purpose registers, r15 is stack pointer during exceptions
@@ -3135,10 +3137,12 @@ ARCH_SETTINGS = [
 def hexify_int(row: str, pat: Match[str], arch: ArchSettings) -> str:
     full = pat.group(0)
 
-    # sh2/sh4 only has 8-bit immediates, just convert them uniformly without
-    # any -hex stuff
+    # sh2/sh4 only has signed 8-bit immediates for some instructions
     if arch.name == "sh2" or arch.name == "sh4" or arch.name == "sh4el":
-        return hex(int(full) & 0xFF)
+        if "add" in row or "mov" in row or "cmp/eq" in row:
+            return hex(int(full))
+        else:
+            return hex(int(full) & 0xFF)
 
     if len(full) <= 1:
         # leave one-digit ints alone

--- a/diff.py
+++ b/diff.py
@@ -438,7 +438,6 @@ import threading
 import time
 import traceback
 
-
 MISSING_PREREQUISITES = (
     "Missing prerequisite python module {}. "
     "Run `python3 -m pip install --user colorama watchdog levenshtein cxxfilt` to install prerequisites (cxxfilt only needed with --source)."

--- a/diff.py
+++ b/diff.py
@@ -2220,7 +2220,7 @@ class AsmProcessorX86(AsmProcessor):
             else:
                 repl = f"{repl}+{of}"
 
-        return f"{mnemonic}\t{args[:start]+repl+args[end:]}", repl
+        return f"{mnemonic}\t{args[:start] + repl + args[end:]}", repl
 
     def is_end_of_function(self, mnemonic: str, args: str) -> bool:
         return mnemonic == "ret"
@@ -2234,9 +2234,7 @@ class AsmProcessorX86(AsmProcessor):
 # "mov.l   0x1234,r7"
 # "mov.l   0x4c,r1 ! 605c660"
 # "mova    0x5c,r0"
-SH_POOL_PATTERN = (
-    r"(^.+mov\.?([lwa])\s+)(?:0x)?([a-fA-F0-9]+)(\s*<.+>)?(,r[0-9]+)(?:\s+!\s*([a-fA-F0-9]*))?"
-)
+SH_POOL_PATTERN = r"(^.+mov\.?([lwa])\s+)(?:0x)?([a-fA-F0-9]+)(\s*<.+>)?(,r[0-9]+)(?:\s+!\s*([a-fA-F0-9]*))?"
 
 # Normalized version of the normal pattern that uses pc-relative notation
 # Examples:
@@ -2327,7 +2325,7 @@ class AsmProcessorSH2(AsmProcessor):
             "R_SH_LABEL",
             "R_SH_ALIGN",
         }
-        
+
         # Catalog all relocs, done first just because there might relocs without
         # mov reference, so we can check for these and join them
         for i, line in enumerate(lines):
@@ -2678,7 +2676,7 @@ class AsmProcessorM68k(AsmProcessor):
         else:
             assert False, f"unknown relocation type '{row}' for line '{prev}'"
 
-        return f"{mnemonic}\t{args[:start]+repl+args[end:]}", repl
+        return f"{mnemonic}\t{args[:start] + repl + args[end:]}", repl
 
     def is_end_of_function(self, mnemonic: str, args: str) -> bool:
         return mnemonic == "rts" or mnemonic == "rte" or mnemonic == "rtr"

--- a/diff.py
+++ b/diff.py
@@ -2227,13 +2227,16 @@ class AsmProcessorX86(AsmProcessor):
         return mnemonic == "ret"
 
 
-# pc-relative mov instructions
+# pc-relative mov instructions, with or without the <label> targets
 # Examples:
 # "mov.l   150 <_bar+0x12>,r4     ! 154 <_main>"
 # "mov.w   266 <_main+0x112>,r4   ! bbaa"
 # "mova    190 <_main+0x3c>,r0"
+# "mov.l   0x1234,r7"
+# "mov.l   0x4c,r1 ! 605c660"
+# "mova    0x5c,r0"
 SH_POOL_PATTERN = (
-    r"(^.+mov\.?([lwa])\s+)([a-fA-F0-9]+)\s*<.+>(,r[0-9]+)(?:\s+!\s*([a-fA-F0-9]*))?"
+    r"(^.+mov\.?([lwa])\s+)(?:0x)?([a-fA-F0-9]+)(\s*<.+>)?(,r[0-9]+)(?:\s+!\s*([a-fA-F0-9]*))?"
 )
 
 # Normalized version of the normal pattern that uses pc-relative notation
@@ -2433,14 +2436,14 @@ class AsmProcessorSH2(AsmProcessor):
                     mov_label = self._relocs[addr].split()[-1]
                     mov_comm = ""
                     pc_rel = f"@({mov_label},pc)"
-                    pc_rel += mov_match.group(4)
+                    pc_rel += mov_match.group(5)
                 else:
                     mov_value = -1
 
                     # Can be None if direct values are used but the pool
                     # doesn't get included in the asm
-                    if mov_match.group(5) is not None:
-                        mov_value = int(mov_match.group(5), 16)
+                    if mov_match.group(6) is not None:
+                        mov_value = int(mov_match.group(6), 16)
 
                     self._imms[mov_tgt] = self.ImmEntry(
                         value=mov_value,
@@ -2452,15 +2455,15 @@ class AsmProcessorSH2(AsmProcessor):
                     mov_comm = f" ! {mov_tgt:x}"
                     # Convert to pc-rel notation while we are at it
                     pc_rel = f"@(0x{mov_tgt - addr:x},pc)"
-                    pc_rel += mov_match.group(4)
+                    pc_rel += mov_match.group(5)
 
                 norm_lines.append(fix_line + pc_rel + mov_comm)
                 continue
 
             # Check for jumptables
             if mnemonic == "braf" or mnemonic == "jmp":
-                # search mova up to 4 instructions before
-                mov_lines = lines[i - 1 : i - 5 : -1]
+                # search mova up to 20 instructions before
+                mov_lines = lines[i - 1 : max(-1, i - 20 - 1) : -1]
                 jtbl_match = None
                 is_mova = False
                 jtbl_addr = 0
@@ -2470,11 +2473,14 @@ class AsmProcessorSH2(AsmProcessor):
                     if jtbl_match is not None:
                         is_mova = jtbl_match.group(2) == "a"
                         jtbl_addr = int(jtbl_match.group(3), 16)
+
+                        if not is_mova:
+                            continue
                         break
 
                 if is_mova and addr not in self._relocs:
-                    # Search up to 10 lines before
-                    end = min(i, 10)
+                    # Search up to 60 lines before
+                    end = min(i, 60)
                     jtbl_count = self._test_jtbl(lines[i - 2 : i - end : -1])
 
                     if jtbl_count != -1:
@@ -2508,11 +2514,9 @@ class AsmProcessorSH2(AsmProcessor):
                     jtbl_count = int(mov_match.group(1)) + adjust
                     break
                 # more than 128 cases
-                pat = r"^.+mov.[lw].*<.+>,"
-                pat += cmp_reg + r"\s+!\s*([a-fA-F0-9]*)?"
-                mov_match = re.match(pat, line)
+                mov_match = re.match(SH_POOL_PATTERN, line)
                 if mov_match:
-                    jtbl_count = int(mov_match.group(1), 16) + adjust
+                    jtbl_count = int(mov_match.group(6), 16) + adjust
                     break
 
         return jtbl_count

--- a/diff.py
+++ b/diff.py
@@ -3073,7 +3073,7 @@ SH2_SETTINGS = ArchSettings(
     name="sh2",
     # match -128-127 or 0-255 preceded by a '#' with a ',' after (8 bit immediates)
     re_int=re.compile(
-        r"(?<=#)(-?(?:12[0-7]|1[01][0-9]|[1-9][0-9]?|0)|(?:25[0-5]|2[0-4][0-9]|1[3-9][0-9]|12[8-9]))(?=,)"
+        r"(?<=#)(-?(?:12[0-8]|1[01][0-9]|[1-9][0-9]?|0)|(?:25[0-5]|2[0-4][0-9]|1[3-9][0-9]|12[8-9]))(?=,)"
     ),
     # match <text>, match ! and after
     re_comment=re.compile(r"<.*?>|!.*"),

--- a/diff.py
+++ b/diff.py
@@ -2319,6 +2319,13 @@ class AsmProcessorSH2(AsmProcessor):
     # as an instruction can be fixed, returns a new list of lines that should
     # make the fixup job a bit easier
     def _collect_and_normalize(self, lines: List[str], is_be: bool) -> List[str]:
+        ignored_rels = {
+            "R_SH_CODE",
+            "R_SH_DATA",
+            "R_SH_LABEL",
+            "R_SH_ALIGN",
+        }
+        
         # Catalog all relocs, done first just because there might relocs without
         # mov reference, so we can check for these and join them
         for i, line in enumerate(lines):
@@ -2329,7 +2336,7 @@ class AsmProcessorSH2(AsmProcessor):
             mnemonic = addr_match.group(3) if addr_match else ""
 
             # Reloc line, add to dict
-            if "R_SH_" in mnemonic:
+            if "R_SH_" in mnemonic and mnemonic not in ignored_rels:
                 self._relocs[addr] = line
                 continue
 
@@ -2353,6 +2360,16 @@ class AsmProcessorSH2(AsmProcessor):
             # Reloc line, skip (already collected)
             if "R_SH_" in mnemonic:
                 continue
+
+            # Fixup BSR targets if they have a relocation
+            if mnemonic == "bsr" and addr in self._relocs:
+                rel_line = self._relocs[addr]
+                symbol = rel_line.split("+")[0]
+                if symbol != ".text":
+                    target = int(rel_line.split("+")[-1], 16) + 4
+                    nline = line.split("\tbsr\t")[0]
+                    norm_lines.append(f"{nline}\tbsr\t{target:x}")
+                    continue
 
             # Address reloc has an entry but isn't from a mov reference, add it as one
             if addr in self._relocs and addr not in self._imms:
@@ -2544,7 +2561,7 @@ class AsmProcessorSH2(AsmProcessor):
             )
             return f"{before}{repl}{after}", repl
         elif "R_SH_IND12W" in row:
-            # bra <label>
+            # bra <label> or bsr <label>, the latter is handled during pre_process
             return prev, None
         elif "R_SH_DIR8WPL" in row:
             # pc-rel mov.l <label>

--- a/diff.py
+++ b/diff.py
@@ -3084,7 +3084,7 @@ SH4_SETTINGS = replace(
     #   - fr0-fr15, dr0-dr14, xd0-xd14, fv0-fv12 FP registers
     #     dr/xd registers can only be even-numbered, and fv registers can only be a multiple of 4
     re_reg=re.compile(
-        r"r1[0-5]|r[0-9]|fr1[0-5]|fr[0-9]|dr[02468]|dr1[024]|xd[02468]|xd1[024]|fv[048]|fv12"
+        r"r1[0-5]|r[0-9]|fr1[0-5]|fr[0-9]|dr[02468]|dr1[024]|(?<!0)xd[02468]|(?<!0)xd1[024]|fv[048]|fv12"
     ),
     arch_flags=["-m", "sh4"],
 )

--- a/test.py
+++ b/test.py
@@ -64,13 +64,29 @@ class TestSh2(unittest.TestCase):
         # func_0606B760():
         # 0:   ec 01           mov     #1,r12
         # 2:   71 01           add     #1,r1
-        # 4:   ec ff           mov     #-1,r12
-        # 6:   71 ff           add     #-1,r1
-        # 8:   ec 7f           mov     #127,r12
-        # a:   71 7f           add     #127,r1
-        # c:   ec 80           mov     #-128,r12
-        # e:   71 80           add     #-128,r1
-        sh2_theirs = "func_0606B760():\n   0:\tec 01       \tmov\t#1,r12\n   2:\t71 01       \tadd\t#1,r1\n   4:\tec ff       \tmov\t#-1,r12\n   6:\t71 ff       \tadd\t#-1,r1\n   8:\tec 7f       \tmov\t#127,r12\n   a:\t71 7f       \tadd\t#127,r1\n   c:\tec 80       \tmov\t#-128,r12\n   e:\t71 80       \tadd\t#-128,r1"
+        # 4:   c8 01           tst     #1,r0
+        # 6:   c9 01           and     #1,r0
+        # 8:   cb 01           or      #1,r0
+        # a:   ca 01           xor     #1,r0
+        # c:   ec ff           mov     #-1,r12
+        # e:   71 ff           add     #-1,r1
+        # 10:   c8 ff           tst     #255,r0
+        # 12:   c9 ff           and     #255,r0
+        # 14:   cb ff           or      #255,r0
+        # 16:   ca ff           xor     #255,r0
+        # 18:   ec 7f           mov     #127,r12
+        # 1a:   71 7f           add     #127,r1
+        # 1c:   c8 7f           tst     #127,r0
+        # 1e:   c9 7f           and     #127,r0
+        # 20:   cb 7f           or      #127,r0
+        # 22:   ca 7f           xor     #127,r0
+        # 24:   ec 80           mov     #-128,r12
+        # 26:   71 80           add     #-128,r1
+        # 28:   c8 80           tst     #128,r0
+        # 2a:   c9 80           and     #128,r0
+        # 2c:   cb 80           or      #128,r0
+        # 2e:   ca 80           xor     #128,r0
+        sh2_theirs = "func_0606B760():\n   0:\tec 01       \tmov\t#1,r12\n   2:\t71 01       \tadd\t#1,r1\n   4:\tc8 01       \ttst\t#1,r0\n   6:\tc9 01       \tand\t#1,r0\n   8:\tcb 01       \tor\t#1,r0\n   a:\tca 01       \txor\t#1,r0\n   c:\tec ff       \tmov\t#-1,r12\n   e:\t71 ff       \tadd\t#-1,r1\n  10:\tc8 ff       \ttst\t#255,r0\n  12:\tc9 ff       \tand\t#255,r0\n  14:\tcb ff       \tor\t#255,r0\n  16:\tca ff       \txor\t#255,r0\n  18:\tec 7f       \tmov\t#127,r12\n  1a:\t71 7f       \tadd\t#127,r1\n  1c:\tc8 7f       \ttst\t#127,r0\n  1e:\tc9 7f       \tand\t#127,r0\n  20:\tcb 7f       \tor\t#127,r0\n  22:\tca 7f       \txor\t#127,r0\n  24:\tec 80       \tmov\t#-128,r12\n  26:\t71 80       \tadd\t#-128,r1\n  28:\tc8 80       \ttst\t#128,r0\n  2a:\tc9 80       \tand\t#128,r0\n  2c:\tcb 80       \tor\t#128,r0\n  2e:\tca 80       \txor\t#128,r0"
 
         # just diff with self
         sh2_ours = sh2_theirs
@@ -82,12 +98,28 @@ class TestSh2(unittest.TestCase):
         expected = [
             "0:    mov     #0x1,r12",
             "2:    add     #0x1,r1",
-            "4:    mov     #0xff,r12",
-            "6:    add     #0xff,r1",
-            "8:    mov     #0x7f,r12",
-            "a:    add     #0x7f,r1",
-            "c:    mov     #0x80,r12",
-            "e:    add     #0x80,r1",
+            "4:    tst     #0x1,r0",
+            "6:    and     #0x1,r0",
+            "8:    or      #0x1,r0",
+            "a:    xor     #0x1,r0",
+            "c:    mov     #-0x1,r12",
+            "e:    add     #-0x1,r1",
+            "10:    tst     #0xff,r0",
+            "12:    and     #0xff,r0",
+            "14:    or      #0xff,r0",
+            "16:    xor     #0xff,r0",
+            "18:    mov     #0x7f,r12",
+            "1a:    add     #0x7f,r1",
+            "1c:    tst     #0x7f,r0",
+            "1e:    and     #0x7f,r0",
+            "20:    or      #0x7f,r0",
+            "22:    xor     #0x7f,r0",
+            "24:    mov     #-0x80,r12",
+            "26:    add     #-0x80,r1",
+            "28:    tst     #0x80,r0",
+            "2a:    and     #0x80,r0",
+            "2c:    or      #0x80,r0",
+            "2e:    xor     #0x80,r0",
         ]
 
         i = 0
@@ -139,15 +171,15 @@ class TestSh2(unittest.TestCase):
             "10:    add     #0x6d,r1",
             "12:    add     #0x6f,r1",
             "14:    add     #0x77,r1",
-            "16:    add     #0xf7,r1",
-            "18:    add     #0xf6,r1",
-            "1a:    add     #0xf5,r1",
-            "1c:    add     #0xed,r1",
-            "1e:    add     #0x9c,r1",
-            "20:    add     #0x9b,r1",
-            "22:    add     #0x93,r1",
-            "24:    add     #0x91,r1",
-            "26:    add     #0x89,r1",
+            "16:    add     #-0x9,r1",
+            "18:    add     #-0xa,r1",
+            "1a:    add     #-0xb,r1",
+            "1c:    add     #-0x13,r1",
+            "1e:    add     #-0x64,r1",
+            "20:    add     #-0x65,r1",
+            "22:    add     #-0x6d,r1",
+            "24:    add     #-0x6f,r1",
+            "26:    add     #-0x77,r1",
         ]
 
         i = 0


### PR DESCRIPTION
Mainly extends the jumptable search range because seems like GCC can put a literal pool in between the comparison and the `mova`.